### PR TITLE
fix(exam-form): enforce subject ≤30 chars and time 45–240 min (#34)

### DIFF
--- a/client/src/components/exams/ExamForm.tsx
+++ b/client/src/components/exams/ExamForm.tsx
@@ -73,7 +73,7 @@ export const ExamForm = forwardRef<ExamFormHandle, Props>(function ExamForm(
     if (step === 0) return !!(values.subject && values.difficulty && values.attempts);
     if (step === 1) return totalQuestions > 0;
     if (step === 2) return !!values.timeMinutes;
-    return false;
+    return Boolean(values.timeMinutes) && !errors.timeMinutes;
   };
 
   const hasQuestions = totalQuestions > 0;
@@ -163,11 +163,11 @@ export const ExamForm = forwardRef<ExamFormHandle, Props>(function ExamForm(
           {step === 0 && <>
             <div className="form-group">
               <label htmlFor="subject">Materia *</label>
-              <input id="subject" name="subject" type="text" maxLength={80}
+              <input id="subject" name="subject" type="text" maxLength={30}
                 className="input-hover subject-hover"
                 placeholder="Ej: Algorítmica 1"
                 value={values.subject || ''} onChange={e=>onChange('subject', e.target.value)} />
-              <small className="help">Máx. 80 caracteres</small>
+              <small className="help">Máx. 30 caracteres</small>
               {errors.subject && <small className="error">{errors.subject}</small>}
             </div>
 
@@ -243,7 +243,7 @@ export const ExamForm = forwardRef<ExamFormHandle, Props>(function ExamForm(
           {step === 2 && <>
             <div className="form-group">
               <label htmlFor="timeMinutes">Tiempo (min) *</label>
-              <input id="timeMinutes" name="timeMinutes" type="number" min={1} step={1} placeholder="45"
+              <input id="timeMinutes" name="timeMinutes" type="number" min={45} max={240} step={1} placeholder="45"
                 className="input-hover"
                 value={values.timeMinutes || ''} onChange={e=>onChange('timeMinutes', e.target.value)} />
               {errors.timeMinutes && <small className="error">{errors.timeMinutes}</small>}

--- a/client/src/hooks/useExamForm.ts
+++ b/client/src/hooks/useExamForm.ts
@@ -12,7 +12,7 @@ type Values = {
   openEnded: string | number;    
 };
 
-const limits = { subjectMax: 80, referenceMax: 1000 };
+const limits = { subjectMax: 30, referenceMax: 1000, timeMin: 45, timeMax: 240 };
 
 const toInt = (v: any) => Number.isInteger(Number(v)) ? Number(v) : NaN;
 const isPosInt = (v: any) => {
@@ -87,7 +87,13 @@ export function useExamForm() {
     }
 
     if (!isPosInt(values.attempts)) errors.attempts = 'Los intentos deben ser mayor a 0';
-    if (!isPosInt(values.timeMinutes)) errors.timeMinutes = 'El tiempo debe ser mayor a 0';
+    if (!isPosInt(values.timeMinutes)) {
+      errors.timeMinutes = 'Debe ser entero.';
+    } else {
+      const t = toInt(values.timeMinutes);
+      if (t < limits.timeMin) errors.timeMinutes = `Mínimo ${limits.timeMin} minutos.`;
+      else if (t > limits.timeMax) errors.timeMinutes = `Máximo ${limits.timeMax} minutos (4 horas).`;
+    }
 
     ([
       ['multipleChoice','Opción múltiple'],
@@ -131,7 +137,16 @@ export function useExamForm() {
       return;
     }
     if (name === 'timeMinutes') {
-      if (!isPosInt(value)) errors.timeMinutes = 'El tiempo debe ser mayor a 0'; else delete errors.timeMinutes;
+      const n = toInt(value);
+      if (!Number.isInteger(n)) {
+        errors.timeMinutes = 'Debe ser entero.';
+      } else if (n < limits.timeMin) {
+        errors.timeMinutes = `Mínimo ${limits.timeMin} minutos.`;
+      } else if (n > limits.timeMax) {
+        errors.timeMinutes = `Máximo ${limits.timeMax} minutos (4 horas).`;
+      } else {
+        delete errors.timeMinutes;
+      }
       return;
     }
     if (['multipleChoice','trueFalse','analysis','openEnded'].includes(name as string)) {


### PR DESCRIPTION
### Summary
Enforce sensible limits on Exam Form:
- Subject: max 30 chars
- Time: 45–240 minutes (4 hours)

### Changes
- UI (ExamForm.tsx): subject maxLength=30 + help text; time min=45, max=240; step validation blocks submit when time invalid
- Hook (useExamForm.ts): subject ≤30; time integer and within [45..240]