### PR TITLE
feat(exams): DB models + domain contracts for adding questions (#43)

### DIFF
--- a/backend/src/modules/exams/application/commands/add-exam-question.command.ts
+++ b/backend/src/modules/exams/application/commands/add-exam-question.command.ts
@@ -1,0 +1,10 @@
+import { NewExamQuestion } from '../../domain/entities/exam-question.entity';
+import { InsertPosition } from '../../domain/ports/exam-question.repository.port';
+
+export class AddExamQuestionCommand {
+  constructor(
+    public readonly examId: string,
+    public readonly position: InsertPosition,
+    public readonly question: NewExamQuestion,
+  ) {}
+}

--- a/backend/src/modules/exams/application/commands/add-exam-question.handler.ts
+++ b/backend/src/modules/exams/application/commands/add-exam-question.handler.ts
@@ -1,0 +1,54 @@
+import { BadRequestException, Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { AddExamQuestionCommand } from './add-exam-question.command';
+import { EXAM_QUESTION_REPO } from '../../tokens';
+import type { ExamQuestionRepositoryPort } from '../../domain/ports/exam-question.repository.port';
+
+@Injectable()
+export class AddExamQuestionCommandHandler {
+  constructor(
+    @Inject(EXAM_QUESTION_REPO) private readonly repo: ExamQuestionRepositoryPort,
+  ) {}
+
+  async execute(cmd: AddExamQuestionCommand) {
+    const { examId, position, question } = cmd;
+
+    if (!(await this.repo.existsExam(examId))) {
+      throw new NotFoundException('Exam not found');
+    }
+
+    this.validateQuestion(question);
+    return this.repo.addToExam(examId, question, position);
+  }
+
+  private validateQuestion(q: any) {
+    const allowed = ['MULTIPLE_CHOICE', 'TRUE_FALSE', 'OPEN_ANALYSIS', 'OPEN_EXERCISE'];
+    if (!allowed.includes(q.kind)) {
+      throw new BadRequestException(`Unsupported kind. Allowed: ${allowed.join(', ')}`);
+    }
+    if (!q.text || typeof q.text !== 'string' || q.text.trim().length < 5) {
+      throw new BadRequestException('Question text is required (min 5 chars).');
+    }
+
+    if (q.kind === 'MULTIPLE_CHOICE') {
+      if (!Array.isArray(q.options) || q.options.length < 2 || q.options.length > 8) {
+        throw new BadRequestException('MCQ requires 2..8 options.');
+      }
+      if (typeof q.correctOptionIndex !== 'number') {
+        throw new BadRequestException('MCQ requires correctOptionIndex.');
+      }
+      if (q.correctOptionIndex < 0 || q.correctOptionIndex >= q.options.length) {
+        throw new BadRequestException('correctOptionIndex out of range.');
+      }
+    }
+
+    if (q.kind === 'TRUE_FALSE' && typeof q.correctBoolean !== 'boolean') {
+      throw new BadRequestException('TRUE_FALSE requires correctBoolean (true|false).');
+    }
+
+    if ((q.kind === 'OPEN_ANALYSIS' || q.kind === 'OPEN_EXERCISE') && q.expectedAnswer != null) {
+      if (typeof q.expectedAnswer !== 'string') {
+        throw new BadRequestException('expectedAnswer must be a string if provided.');
+      }
+    }
+  }
+}

--- a/backend/src/modules/exams/domain/entities/exam-question.entity.ts
+++ b/backend/src/modules/exams/domain/entities/exam-question.entity.ts
@@ -1,0 +1,22 @@
+export type QuestionKind =
+  | 'MULTIPLE_CHOICE'
+  | 'TRUE_FALSE'
+  | 'OPEN_ANALYSIS'
+  | 'OPEN_EXERCISE';
+
+export interface NewExamQuestion {
+  kind: QuestionKind;
+  text: string;
+  options?: string[];          // MCQ
+  correctOptionIndex?: number; // MCQ
+  correctBoolean?: boolean;    // TRUE_FALSE
+  expectedAnswer?: string;     // OPEN_*
+}
+
+export interface ExamQuestion extends NewExamQuestion {
+  id: string;
+  examId: string;
+  order: number;
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/backend/src/modules/exams/domain/ports/exam-question.repository.port.ts
+++ b/backend/src/modules/exams/domain/ports/exam-question.repository.port.ts
@@ -1,0 +1,13 @@
+import { ExamQuestion, NewExamQuestion } from '../entities/exam-question.entity';
+
+export type InsertPosition = 'start' | 'middle' | 'end';
+
+export interface ExamQuestionRepositoryPort {
+  existsExam(examId: string): Promise<boolean>;
+  countByExam(examId: string): Promise<number>;
+  addToExam(
+    examId: string,
+    question: NewExamQuestion,
+    position: InsertPosition
+  ): Promise<ExamQuestion>;
+}

--- a/backend/src/modules/exams/exams.module.ts
+++ b/backend/src/modules/exams/exams.module.ts
@@ -10,6 +10,10 @@ import { AiConfigService } from '../../core/ai/ai.config';
 import { LlmModule } from '../llm/llm.module';
 import { PromptTemplateModule } from '../prompt-template/prompt-template.module';
 import { GenerateExamUseCase } from './application/commands/generate-exam.usecase';
+import { ExamQuestionPrismaRepository } from './infrastructure/persistence/exam-question.prisma.repository';
+import { EXAM_QUESTION_REPO } from './tokens';
+import { AddExamQuestionCommandHandler } from './application/commands/add-exam-question.handler';
+
 
 @Module({
   imports: [PrismaModule, LlmModule, PromptTemplateModule],
@@ -23,6 +27,8 @@ import { GenerateExamUseCase } from './application/commands/generate-exam.usecas
     GenerateExamUseCase,
     CreateExamCommandHandler,
     GenerateQuestionsCommandHandler,
+    { provide: EXAM_QUESTION_REPO, useClass: ExamQuestionPrismaRepository },
+    AddExamQuestionCommandHandler,
   ],
 })
 export class ExamsModule {}

--- a/backend/src/modules/exams/infrastructure/http/dtos/add-exam-question.dto.ts
+++ b/backend/src/modules/exams/infrastructure/http/dtos/add-exam-question.dto.ts
@@ -1,0 +1,27 @@
+import { IsArray, IsBoolean, IsEnum, IsIn, IsInt, IsNotEmpty, IsOptional, IsString, MaxLength, Min } from 'class-validator';
+
+export class AddExamQuestionDto {
+  @IsEnum(['MULTIPLE_CHOICE','TRUE_FALSE','OPEN_ANALYSIS','OPEN_EXERCISE'] as any)
+  kind!: 'MULTIPLE_CHOICE'|'TRUE_FALSE'|'OPEN_ANALYSIS'|'OPEN_EXERCISE';
+
+  @IsString() @IsNotEmpty() @MaxLength(4000)
+  text!: string;
+
+  // MCQ
+  @IsOptional() @IsArray()
+  options?: string[];
+
+  @IsOptional() @IsInt() @Min(0)
+  correctOptionIndex?: number;
+
+  // TRUE_FALSE
+  @IsOptional() @IsBoolean()
+  correctBoolean?: boolean;
+
+  // OPEN_*
+  @IsOptional() @IsString()
+  expectedAnswer?: string;
+
+  @IsIn(['start','middle','end'])
+  position!: 'start'|'middle'|'end';
+}

--- a/backend/src/modules/exams/infrastructure/http/exams.controller.ts
+++ b/backend/src/modules/exams/infrastructure/http/exams.controller.ts
@@ -11,6 +11,10 @@ import {
 } from '../../application/commands/generate-questions.command';
 import type { GenerateExamInput } from './dtos/exam.types';
 import { GenerateExamUseCase } from '../../application/commands/generate-exam.usecase';
+import { Param } from '@nestjs/common';
+import { AddExamQuestionDto } from './dtos/add-exam-question.dto';
+import { AddExamQuestionCommand } from '../../application/commands/add-exam-question.command';
+import { AddExamQuestionCommandHandler } from '../../application/commands/add-exam-question.handler';
 
 function sumDistribution(d?: { multiple_choice: number; true_false: number; open_analysis: number; open_exercise: number; }) {
   if (!d) return 0;
@@ -26,7 +30,25 @@ export class ExamsController {
     private readonly createExamHandler: CreateExamCommandHandler,
     private readonly generateQuestionsHandler: GenerateQuestionsCommandHandler,
     private readonly generateExamHandler: GenerateExamUseCase,
+    private readonly addExamQuestionHandler: AddExamQuestionCommandHandler,
   ) {}
+
+  @Post(':id/questions')
+  async addQuestion(
+    @Param('id') id: string,
+    @Body() dto: AddExamQuestionDto,
+  ) {
+    const cmd = new AddExamQuestionCommand(id, dto.position, {
+      kind: dto.kind,
+      text: dto.text,
+      options: dto.options,
+      correctOptionIndex: dto.correctOptionIndex,
+      correctBoolean: dto.correctBoolean,
+      expectedAnswer: dto.expectedAnswer,
+    });
+    const created = await this.addExamQuestionHandler.execute(cmd);
+    return { ok: true, data: created, message: 'Question added to exam' };
+  }
 
   @Post()
   @HttpCode(200)

--- a/backend/src/modules/exams/infrastructure/persistence/exam-question.prisma.repository.ts
+++ b/backend/src/modules/exams/infrastructure/persistence/exam-question.prisma.repository.ts
@@ -1,0 +1,73 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../../../../core/prisma/prisma.service';
+import type { ExamQuestionRepositoryPort, InsertPosition } from '../../domain/ports/exam-question.repository.port';
+import type { ExamQuestion, NewExamQuestion } from '../../domain/entities/exam-question.entity';
+import { Prisma } from '@prisma/client';
+
+@Injectable()
+export class ExamQuestionPrismaRepository implements ExamQuestionRepositoryPort {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async existsExam(examId: string): Promise<boolean> {
+    const c = await this.prisma.exam.count({ where: { id: examId } });
+    return c > 0;
+  }
+
+  async countByExam(examId: string): Promise<number> {
+    return this.prisma.examQuestion.count({ where: { examId } });
+  }
+
+  async addToExam(examId: string, q: NewExamQuestion, position: InsertPosition): Promise<ExamQuestion> {
+    return this.prisma.$transaction(async (tx) => {
+      const count = await tx.examQuestion.count({ where: { examId } });
+
+      let insertionOrder = 1;
+      if (position === 'start') insertionOrder = 1;
+      else if (position === 'end') insertionOrder = count + 1;
+      else if (position === 'middle') insertionOrder = Math.floor(count / 2) + 1;
+
+      if (insertionOrder <= count) {
+        await tx.examQuestion.updateMany({
+          where: { examId, order: { gte: insertionOrder } },
+          data: { order: { increment: 1 } },
+        });
+      }
+
+      const created = await tx.examQuestion.create({
+        data: {
+          examId,
+          kind: q.kind as any, // Prisma enum coincide con los strings
+          text: q.text,
+          options: q.options ? (q.options as unknown as Prisma.InputJsonValue) : undefined,
+          correctOptionIndex: q.correctOptionIndex ?? null,
+          correctBoolean: q.correctBoolean ?? null,
+          expectedAnswer: q.expectedAnswer ?? null,
+          order: insertionOrder,
+        },
+      });
+
+      // sincroniza contadores + totalQuestions en el mismo commit
+      const data: Prisma.ExamUpdateArgs['data'] = { totalQuestions: { increment: 1 } };
+      if (q.kind === 'MULTIPLE_CHOICE') data.mcqCount = { increment: 1 };
+      else if (q.kind === 'TRUE_FALSE') data.trueFalseCount = { increment: 1 };
+      else if (q.kind === 'OPEN_ANALYSIS') data.openAnalysisCount = { increment: 1 };
+      else if (q.kind === 'OPEN_EXERCISE') data.openExerciseCount = { increment: 1 };
+
+      await tx.exam.update({ where: { id: examId }, data });
+
+      return {
+        id: created.id,
+        examId: created.examId,
+        kind: q.kind,
+        text: created.text,
+        options: (created as any).options ?? undefined,
+        correctOptionIndex: created.correctOptionIndex ?? undefined,
+        correctBoolean: created.correctBoolean ?? undefined,
+        expectedAnswer: created.expectedAnswer ?? undefined,
+        order: created.order,
+        createdAt: created.createdAt,
+        updatedAt: created.updatedAt,
+      };
+    });
+  }
+}


### PR DESCRIPTION
# Summary

Implements the API and logic to add questions to an existing exam without altering previously created ones. Supports insertion at the beginning, middle, or end, atomically reordering the `order` field. Updates `totalQuestions` and counters by question type.

