### PR TITLE
[#55] feat(exams): persistence and management of approved exams (backend)

### DIFF
--- a/backend/prisma/migrations/20250905022502_init_schema/migration.sql
+++ b/backend/prisma/migrations/20250905022502_init_schema/migration.sql
@@ -1,0 +1,21 @@
+-- CreateEnum
+CREATE TYPE "public"."ExamStorageStatus" AS ENUM ('Guardado', 'Publicado');
+
+-- CreateTable
+CREATE TABLE "public"."SavedExam" (
+    "id" SERIAL NOT NULL,
+    "title" TEXT NOT NULL,
+    "content" JSONB NOT NULL,
+    "status" "public"."ExamStorageStatus" NOT NULL DEFAULT 'Guardado',
+    "courseId" TEXT NOT NULL,
+    "teacherId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "SavedExam_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "SavedExam_courseId_createdAt_idx" ON "public"."SavedExam"("courseId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "SavedExam_teacherId_createdAt_idx" ON "public"."SavedExam"("teacherId", "createdAt");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -328,6 +328,27 @@ enum QuestionKind {
   OPEN_ANALYSIS
   OPEN_EXERCISE
 }
+// Estado de publicación del examen guardado
+enum ExamStorageStatus {
+  Guardado
+  Publicado
+}
+
+model SavedExam {
+  id        Int               @id @default(autoincrement())
+  title     String
+  content   Json
+  status    ExamStorageStatus @default(Guardado)
+
+  // FK “lógicas” (sin relación Prisma)
+  courseId  String
+  teacherId String
+
+  createdAt DateTime          @default(now())
+
+  @@index([courseId, createdAt])
+  @@index([teacherId, createdAt])
+}
 
 model ExamQuestion {
   id                 String       @id @default(cuid())

--- a/backend/src/modules/exams/application/commands/save-approved-exam.usecase.ts
+++ b/backend/src/modules/exams/application/commands/save-approved-exam.usecase.ts
@@ -1,0 +1,43 @@
+import { BadRequestException, ForbiddenException, Inject, Injectable } from '@nestjs/common';
+import { PrismaService } from '../../../../core/prisma/prisma.service';
+import { SAVED_EXAM_REPO } from '../../tokens';
+import type { SavedExamRepositoryPort } from '../../domain/ports/saved-exam.repository.port';
+
+export type SaveApprovedExamCommand = {
+  title: string;
+  content: any;       
+  courseId: string;
+  teacherId: string;  
+  status?: 'Guardado'|'Publicado';
+};
+
+@Injectable()
+export class SaveApprovedExamUseCase {
+  constructor(
+    private readonly prisma: PrismaService,
+    @Inject(SAVED_EXAM_REPO) private readonly repo: SavedExamRepositoryPort,
+  ) {}
+
+  async execute(cmd: SaveApprovedExamCommand) {
+    if (!cmd.title?.trim()) throw new BadRequestException('Datos inválidos: title requerido.');
+    if (!cmd.courseId?.trim()) throw new BadRequestException('Datos inválidos: courseId requerido.');
+    if (cmd.content == null) throw new BadRequestException('Datos inválidos: content requerido.');
+
+    const teacher = await this.prisma.teacherProfile.findUnique({ where: { userId: cmd.teacherId } });
+    if (!teacher) throw new ForbiddenException('Acceso no autorizado (se requiere rol docente).');
+
+    const course = await this.prisma.course.findUnique({ where: { id: cmd.courseId } });
+    if (!course) throw new BadRequestException('Datos inválidos: courseId no existe.');
+    if (course.teacherId !== cmd.teacherId) {
+      throw new ForbiddenException('Acceso no autorizado al curso.');
+    }
+
+    return this.repo.save({
+      title: cmd.title.trim(),
+      content: cmd.content,
+      courseId: cmd.courseId,
+      teacherId: cmd.teacherId,
+      status: cmd.status ?? 'Guardado',
+    });
+  }
+}

--- a/backend/src/modules/exams/application/queries/list-course-exams.usecase.ts
+++ b/backend/src/modules/exams/application/queries/list-course-exams.usecase.ts
@@ -1,0 +1,27 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { PrismaService } from '../../../../core/prisma/prisma.service';
+import { COURSE_EXAMS_HARDCODED, SAVED_EXAM_REPO } from '../../tokens';
+import type { SavedExamRepositoryPort, SavedExamDTO } from '../../domain/ports/saved-exam.repository.port';
+import type { CourseExamsProvider } from '../../infrastructure/http/providers/course-hardcoded-exams.provider';
+
+export type ListCourseExamsQuery = { courseId: string; teacherId: string };
+
+@Injectable()
+export class ListCourseExamsUseCase {
+  constructor(
+    private readonly prisma: PrismaService,
+    @Inject(SAVED_EXAM_REPO) private readonly repo: SavedExamRepositoryPort,
+    @Inject(COURSE_EXAMS_HARDCODED) private readonly provider: CourseExamsProvider,
+  ) {}
+
+  async execute(q: ListCourseExamsQuery): Promise<SavedExamDTO[]> {
+    const course = await this.prisma.course.findUnique({ where: { id: q.courseId } });
+    if (!course) return [];
+    if (course.teacherId !== q.teacherId) return [];
+
+    const saved = await this.repo.listByCourse(q.courseId, q.teacherId);
+    const hardcoded = await this.provider.list(q.courseId);
+
+    return [...saved, ...hardcoded];
+  }
+}

--- a/backend/src/modules/exams/domain/ports/saved-exam.repository.port.ts
+++ b/backend/src/modules/exams/domain/ports/saved-exam.repository.port.ts
@@ -1,0 +1,23 @@
+export interface SaveApprovedExamInput {
+  title: string;
+  content: any;
+  courseId: string;
+  teacherId: string;
+  status?: 'Guardado' | 'Publicado';
+}
+
+export interface SavedExamDTO {
+  id: number;
+  title: string;
+  content: any;
+  status: 'Guardado' | 'Publicado';
+  courseId: string;
+  teacherId: string;
+  createdAt: Date;
+  source?: 'saved' | 'hardcoded';
+}
+
+export interface SavedExamRepositoryPort {
+  save(data: SaveApprovedExamInput): Promise<SavedExamDTO>;
+  listByCourse(courseId: string, teacherId?: string): Promise<SavedExamDTO[]>;
+}

--- a/backend/src/modules/exams/exams.module.ts
+++ b/backend/src/modules/exams/exams.module.ts
@@ -14,6 +14,34 @@ import { ExamQuestionPrismaRepository } from './infrastructure/persistence/exam-
 import { AddExamQuestionCommandHandler } from './application/commands/add-exam-question.handler';
 import { UpdateExamQuestionCommandHandler } from './application/commands/update-exam-question.handler';
 import { ApproveExamCommandHandler } from './application/commands/approve-exam.handler';
+import { SavedExamPrismaRepository } from './infrastructure/persistence/saved-exam.prisma.repository';
+import { SaveApprovedExamUseCase } from './application/commands/save-approved-exam.usecase';
+import { ListCourseExamsUseCase } from './application/queries/list-course-exams.usecase';
+import { SAVED_EXAM_REPO, COURSE_EXAMS_HARDCODED } from './tokens';
+import { SimpleCourseExamsProvider } from './infrastructure/http/providers/course-hardcoded-exams.provider';
+import { ApprovedExamsController } from './infrastructure/http/approved-exams.controller';
+import { TOKEN_SERVICE } from '../identity/tokens';
+
+function decodeJwtPayload(token: string): any {
+  const raw = token.startsWith('Bearer ') ? token.slice(7) : token;
+  const parts = raw.split('.');
+  if (parts.length < 2) throw new Error('Invalid JWT');
+
+  let b64url = parts[1].trim();
+
+  b64url = b64url.replace(/[^A-Za-z0-9\-_]/g, '');
+
+  let b64 = b64url.replace(/-/g, '+').replace(/_/g, '/');
+
+  const pad = b64.length % 4;
+  if (pad) b64 += '='.repeat(4 - pad);
+
+  const json = Buffer.from(b64, 'base64').toString('utf8');
+  return JSON.parse(json);
+}
+const DevTokenService = {
+  verifyAccess: (token: string) => decodeJwtPayload(token),
+};
 
 @Module({
   imports: [
@@ -28,6 +56,8 @@ import { ApproveExamCommandHandler } from './application/commands/approve-exam.h
     { provide: LLM_PORT, useExisting: GeminiAdapter },
 
     { provide: EXAM_AI_GENERATOR, useClass: LlmAiQuestionGenerator },
+    { provide: SAVED_EXAM_REPO, useClass: SavedExamPrismaRepository },
+    { provide: COURSE_EXAMS_HARDCODED, useClass: SimpleCourseExamsProvider },
 
     GenerateExamUseCase,
     CreateExamCommandHandler,
@@ -35,7 +65,11 @@ import { ApproveExamCommandHandler } from './application/commands/approve-exam.h
     AddExamQuestionCommandHandler,
     UpdateExamQuestionCommandHandler,
     ApproveExamCommandHandler,
+    SaveApprovedExamUseCase,
+    ListCourseExamsUseCase,
+    
+    { provide: TOKEN_SERVICE, useValue: DevTokenService },
   ],
-  controllers: [ExamsController],
+  controllers: [ExamsController, ApprovedExamsController],
 })
 export class ExamsModule {}

--- a/backend/src/modules/exams/infrastructure/http/approved-exams.controller.ts
+++ b/backend/src/modules/exams/infrastructure/http/approved-exams.controller.ts
@@ -1,0 +1,50 @@
+import { Body, Controller, Get, Param, Post, Req, UseGuards, BadRequestException, ForbiddenException, InternalServerErrorException } from '@nestjs/common';
+import type { Request } from 'express';
+import { JwtAuthGuard } from 'src/shared/guards/jwt-auth.guard';
+import { responseSuccess } from 'src/shared/handler/http.handler';
+import { SaveApprovedExamDto } from './dtos/save-approved-exam.dto';
+import { SaveApprovedExamUseCase } from '../../application/commands/save-approved-exam.usecase';
+import { ListCourseExamsUseCase } from '../../application/queries/list-course-exams.usecase';
+
+const cid = (req: Request) => req.header('x-correlation-id') ?? crypto.randomUUID();
+const pathOf = (req: Request) => (req as any).originalUrl || req.url || '';
+
+@UseGuards(JwtAuthGuard)
+@Controller()
+export class ApprovedExamsController {
+  constructor(
+    private readonly saveUseCase: SaveApprovedExamUseCase,
+    private readonly listUseCase: ListCourseExamsUseCase,
+  ) {}
+
+  @Post('exams/approved')
+  async save(@Body() dto: SaveApprovedExamDto, @Req() req: Request) {
+    const user = (req as any).user as { sub: string } | undefined;
+    if (!user?.sub) {
+      throw new ForbiddenException('Acceso no autorizado');
+    }
+
+    try {
+      const saved = await this.saveUseCase.execute({
+        title: dto.title,
+        content: dto.content,
+        courseId: dto.courseId,
+        status: dto.status ?? 'Guardado',
+        teacherId: user.sub,
+      });
+      return responseSuccess(cid(req), saved, 'Examen guardado', pathOf(req));
+    } catch (e) {
+      if (e instanceof BadRequestException || e instanceof ForbiddenException) throw e;
+      throw new InternalServerErrorException('Error guardando examen');
+    }
+  }
+
+  @Get('courses/:courseId/exams')
+  async byCourse(@Param('courseId') courseId: string, @Req() req: Request) {
+    const user = (req as any).user as { sub: string } | undefined;
+    if (!user?.sub) throw new ForbiddenException('Acceso no autorizado');
+
+    const data = await this.listUseCase.execute({ courseId, teacherId: user.sub });
+    return responseSuccess(cid(req), data, 'Exámenes del curso', pathOf(req));
+  }
+}

--- a/backend/src/modules/exams/infrastructure/http/dtos/save-approved-exam.dto.ts
+++ b/backend/src/modules/exams/infrastructure/http/dtos/save-approved-exam.dto.ts
@@ -1,0 +1,18 @@
+import { IsEnum, IsNotEmpty, IsOptional, IsString, IsDefined } from 'class-validator';
+
+export class SaveApprovedExamDto {
+  @IsString()
+  @IsNotEmpty()
+  title!: string;
+
+  @IsDefined()
+  content!: any;
+
+  @IsString()
+  @IsNotEmpty()
+  courseId!: string;
+
+  @IsOptional()
+  @IsEnum(['Guardado', 'Publicado'] as any)
+  status?: 'Guardado' | 'Publicado';
+}

--- a/backend/src/modules/exams/infrastructure/http/providers/course-hardcoded-exams.provider.ts
+++ b/backend/src/modules/exams/infrastructure/http/providers/course-hardcoded-exams.provider.ts
@@ -1,0 +1,21 @@
+import type { SavedExamDTO } from '../../../domain/ports/saved-exam.repository.port';
+
+export interface CourseExamsProvider {
+  list(courseId: string): Promise<SavedExamDTO[]>;
+}
+
+export class SimpleCourseExamsProvider implements CourseExamsProvider {
+  async list(courseId: string): Promise<SavedExamDTO[]> {
+    const base: Omit<SavedExamDTO, 'id' | 'createdAt'> = {
+      title: 'Examen Demo (hardcoded)',
+      content: { sections: [], note: 'hardcoded transitional' },
+      status: 'Guardado',
+      courseId,
+      teacherId: 'hardcoded-teacher',
+      source: 'hardcoded',
+    };
+    return [
+      { ...base, id: -1, createdAt: new Date(Date.now() - 86400_000) },
+    ];
+  }
+}

--- a/backend/src/modules/exams/infrastructure/persistence/saved-exam.prisma.repository.ts
+++ b/backend/src/modules/exams/infrastructure/persistence/saved-exam.prisma.repository.ts
@@ -1,0 +1,53 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../../../../core/prisma/prisma.service';
+import type {
+  SaveApprovedExamInput,
+  SavedExamDTO,
+  SavedExamRepositoryPort,
+} from '../../domain/ports/saved-exam.repository.port';
+
+@Injectable()
+export class SavedExamPrismaRepository implements SavedExamRepositoryPort {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async save(data: SaveApprovedExamInput): Promise<SavedExamDTO> {
+    const row = await this.prisma.savedExam.create({
+      data: {
+        title: data.title,
+        content: data.content as any,
+        status: (data.status ?? 'Guardado') as any,
+        courseId: data.courseId,
+        teacherId: data.teacherId,
+      },
+    });
+
+    return {
+      id: row.id,
+      title: row.title,
+      content: row.content,
+      status: row.status as any,
+      courseId: row.courseId,
+      teacherId: row.teacherId,
+      createdAt: row.createdAt,
+      source: 'saved',
+    };
+  }
+
+  async listByCourse(courseId: string, teacherId?: string): Promise<SavedExamDTO[]> {
+    const rows = await this.prisma.savedExam.findMany({
+      where: { courseId, ...(teacherId ? { teacherId } : {}) },
+      orderBy: { createdAt: 'desc' },
+    });
+
+    return rows.map((r) => ({
+      id: r.id,
+      title: r.title,
+      content: r.content,
+      status: r.status as any,
+      courseId: r.courseId,
+      teacherId: r.teacherId,
+      createdAt: r.createdAt,
+      source: 'saved',
+    }));
+    }
+}

--- a/backend/src/modules/exams/tokens.ts
+++ b/backend/src/modules/exams/tokens.ts
@@ -1,3 +1,5 @@
 export const EXAM_REPO = Symbol('EXAM_REPO');
 export const EXAM_AI_GENERATOR = Symbol('EXAM_AI_GENERATOR');
 export const EXAM_QUESTION_REPO = Symbol('EXAM_QUESTION_REPO');
+export const SAVED_EXAM_REPO = Symbol('SAVED_EXAM_REPO');
+export const COURSE_EXAMS_HARDCODED = Symbol('COURSE_EXAMS_HARDCODED');


### PR DESCRIPTION
## Description (for PR)

### What was added

#### Backend Endpoints
- `POST /exams/approved`: stores the JSON snapshot of an approved exam.
- `GET /courses/:courseId/exams`: lists saved exams from the database plus transitional hardcoded mock.

#### Use Cases / Application Logic
- `SaveApprovedExamUseCase`: validates teacher role, course ownership, and input data; persists the exam.
- `ListCourseExamsUseCase`: merges exams from the database with hardcoded ones.

#### Infrastructure / Persistence
- `SavedExamPrismaRepository`: database access for `SavedExam`.

#### DTO / Validation
- `SaveApprovedExamDto`: includes `@IsDefined()` on `content` so that `ValidationPipe` doesn’t strip it out when using whitelist.

#### Transitional Provider
- `SimpleCourseExamsProvider`: returns one “demo” exam (hardcoded source) during migration.

#### Prisma Migration (initial, after local reset)
- `20250905022502_init_schema`: creates the current schema including `enum ExamStorageStatus` and the `SavedExam` table with indexes.

#### Dev Bridge for Auth Guard
- Temporary provider for `TOKEN_SERVICE` (only decodes JWT) to enable `JwtAuthGuard` in this module until `IdentityModule` is integrated.

---

### What was removed

- Nothing.

---

### What was updated

#### Prisma Schema
- `ExamStorageStatus` enum: `{ Saved | Published }`
- `SavedExam` table:
  - `id` (autoincrement)
  - `title`
  - `content` (JSON)
  - `status`
  - `courseId`
  - `teacherId`
  - `createdAt`
  - indexes

#### Module Wiring
- Registration of ports/tokens and guard provider in `ExamsModule`.

#### Exams Module Tokens
- Added `SAVED_EXAM_REPO` and `COURSE_EXAMS_HARDCODED`.
---

### Could it break anything

- **Database**: Requires running migrations (`prisma migrate deploy`) to create the `SavedExam` table and `ExamStorageStatus` enum. Without this, the new endpoints will fail.
- **Auth (dev only)**: The `TOKEN_SERVICE` bridge decodes JWT without verifying signature or expiration. Intended for dev/local use only and must be replaced with the real `IdentityModule` before production.
- **Compatibility**: `Course` and `TeacherProfile` models were not modified (logical FKs only in code), so no impact on other modules.

---

## Files (included changes)

### Added
- `backend/src/modules/exams/application/commands/save-approved-exam.usecase.ts`
- `backend/src/modules/exams/application/queries/list-course-exams.usecase.ts`
- `backend/src/modules/exams/domain/ports/saved-exam.repository.port.ts`
- `backend/src/modules/exams/infrastructure/http/approved-exams.controller.ts`
- `backend/src/modules/exams/infrastructure/http/dtos/save-approved-exam.dto.ts`
- `backend/src/modules/exams/infrastructure/http/providers/course-hardcoded-exams.provider.ts`
- `backend/src/modules/exams/infrastructure/persistence/saved-exam.prisma.repository.ts`
- `backend/prisma/migrations/20250905022502_init_schema/migration.sql`

### Modified
- `backend/prisma/schema.prisma`
- `backend/src/modules/exams/exams.module.ts`
- `backend/src/modules/exams/tokens.ts`

### Deleted
- _(none)_
