### PR TITLE
fix(exams): prevent duplicated questions by normalizing LLM fields in FE/BE

### DIFF
--- a/client/src/pages/exams/AiQuestionsPage.tsx
+++ b/client/src/pages/exams/AiQuestionsPage.tsx
@@ -22,6 +22,23 @@ const layoutStyle: CSSProperties = {
   padding: 'clamp(24px, 3.2vw, 40px) 16px',
 };
 
+const TEXT_KEYS = ['text', 'statement', 'question', 'prompt', 'enunciado', 'descripcion', 'description', 'body', 'content'];
+const OPT_KEYS = ['options', 'choices', 'alternativas', 'opciones', 'answers'];
+const pickTextLike = (q: any) => {
+  for (const k of TEXT_KEYS) {
+    const v = q?.[k];
+    if (typeof v === 'string' && v.trim()) return v.trim();
+  }
+  return '';
+};
+const pickOptionsLike = (q: any) => {
+  for (const k of OPT_KEYS) {
+    const v = q?.[k];
+    if (Array.isArray(v) && v.length) return v.map(String);
+  }
+  return undefined;
+};
+
 function normalizeToQuestions(res: any): GeneratedQuestion[] {
   if (Array.isArray(res)) return res as GeneratedQuestion[];
   const buckets = res?.data?.questions;
@@ -34,8 +51,8 @@ function normalizeToQuestions(res: any): GeneratedQuestion[] {
         out.push({
           id: q.id ?? `${t}_${idx}_${Date.now()}`,
           type: t,
-          text: q.text ?? '',
-          options: q.options ?? undefined,
+          text: pickTextLike(q),
+          options: pickOptionsLike(q),
           include: q.include ?? true,
         } as GeneratedQuestion);
       });


### PR DESCRIPTION
# fix(exams): normalizar campos del LLM para evitar preguntas “duplicadas” en UI

---

## Criterios de aceptación

### Al generar preguntas vía **POST `/exams/questions`** con distribución por tipo:
- [x] Se acepta `text` en claves alternativas: `statement | question | prompt | enunciado | descripcion | description | body | content`.
- [x] Se aceptan opciones en `choices | alternativas | opciones | answers` además de `options`.
- [x] Se mapean alias de tipo:  
  - `multiple-choice | multiple choice | seleccion_multiple` → `multiple_choice`  
  - `boolean | true-false` → `true_false`  
  - `analysis | open-analysis` → `open_analysis`  
  - `exercise | open-exercise` → `open_exercise`
- [x] La respuesta agrupada preserva textos reales del LLM (no vacíos).

### En el **frontend** (Creador de Exámenes):
- [x] Con una distribución (ej.) **MC=2, VF=2, AN=2, EJ=0** se muestran **enunciados distintos** por ítem.
- [x] Si el LLM trae menos ítems de los solicitados, los placeholders se generan numerados y con subject contextual (evitando clones).
- [x] “Regenerar” una sola tarjeta reemplaza **solo** esa pregunta, manteniendo `type` y `include`.
- [x] No se aplica plantilla genérica en español si el texto real ya está en español.

---

## Archivos modificados
- `client/src/services/exams.service.ts`  
- `client/src/pages/exams/AiQuestionsPage.tsx`  
- `backend/src/modules/exams/infrastructure/ai/llm-ai-question.generator.ts`  

---

## Cambios realizados

### Frontend

- **`client/src/services/exams.service.ts`**
  - **NEW**: `TEXT_KEYS` y `OPT_KEYS` para reconocer múltiples claves de texto/opciones provenientes del LLM.
  - **NEW**: helpers `pickTextLike(q)` y `pickOptionsLike(q)` que eligen el primer campo válido.
  - **UPDATE**: `normalizeItem(...)` ahora usa los pickers para evitar `text` vacío (que antes disparaba `forceSpanish(...)` y generaba textos repetidos).
  - **KEEP/IMPROVE**: placeholders mantienen numeración y contexto por `subject` para no parecer duplicados.

- **`client/src/pages/exams/AiQuestionsPage.tsx`**
  - **NEW**: mismos pickers (`TEXT_KEYS`/`OPT_KEYS`) aplicados en `normalizeToQuestions(...)` al consumir la respuesta agrupada, garantizando textos/opciones correctos antes de renderizar.

### Backend

- **`backend/src/modules/exams/infrastructure/ai/llm-ai-question.generator.ts`**
  - **UPDATE**: `mapRawTypeToQuestionType(...)` reconoce alias de tipo (`multiple-choice`, `boolean`, etc.).
  - **NEW**: helpers `textOf(q)` y `optsOf(q)` para mapear texto/opciones desde claves alternativas (`statement/question/enunciado`, `choices/opciones/alternativas/answers`, …).
  - **APPLY**: uso de `textOf/optsOf` tanto en la rama **agrupada** (con `distribution`) como en la rama **array** (sin `distribution`).

---

## Plan de pruebas (manual)

### Backend (Postman)

**Base URL**: `{{API_BASE}}` (p.ej. `http://localhost:3000`)

1. **Generar preguntas agrupadas**
   - **POST** `{{API_BASE}}/exams/questions`  
   - **Body**:
     ```json
     {
       "subject": "Geometría",
       "difficulty": "medio",
       "totalQuestions": 6,
       "distribution": {
         "multiple_choice": 2,
         "true_false": 2,
         "open_analysis": 2,
         "open_exercise": 0
       },
       "language": "es",
       "strict": true
     }
     ```
   - **Esperado (200)**: objeto con `questions.{multiple_choice,true_false,open_analysis,open_exercise}`; cada ítem con `text` **no vacío** (aunque el LLM lo envíe como `statement|question|enunciado`). Si hay `choices|alternativas|opciones|answers`, se mapean a `options`.

2. **Regenerar una sola de tipo específico**
   - Mismo endpoint con `totalQuestions: 1` y distribución de un solo tipo (ej. `true_false: 1`).
   - **Esperado**: un único ítem válido del tipo solicitado, con texto correcto.

### Frontend (UI)

1. Ir a **Exámenes → Crear**.
2. Completar el formulario con `subject = Geometría`, `difficulty = medio`, distribución **MC=2, VF=2, AN=2, EJ=0**.
3. Click **Generar con IA**.
4. **Esperado**: 6 preguntas con **enunciados distintos**; sin plantillas genéricas repetidas.
5. Click en **Regenerar** de una tarjeta → solo esa cambia, respeta `type/include`.
6. Cambiar el `subject` (p.ej. “Algoritmos”) y repetir → no deben aparecer duplicados.

---

## Riesgo y rollback
- **Riesgo bajo**: No se cambian contratos públicos; se robustecen mapeos.
- **Rollback**: revertir este PR vuelve al comportamiento previo.

---

## Notas de compatibilidad
- No requiere migraciones ni cambios en otros módulos.
- El endpoint y DTOs expuestos se mantienen; la capa de normalización ahora es tolerante a variaciones del LLM.

---

## Commits sugeridos (Conventional Commits)
- `fix(frontend/exams): normalize LLM fields (statement/question/enunciado + choices/opciones) to avoid duplicated Spanish templates`
- `fix(backend/ai): support type aliases (multiple-choice/boolean/etc.) and map text/options across common keys`
