### PR TITLE
Fix/36 Option to mark exam

### DIFF
--- a/client/src/components/ai/QuestionCard.tsx
+++ b/client/src/components/ai/QuestionCard.tsx
@@ -18,7 +18,7 @@ export type QuestionCardProps = {
   onDragOver?: (e: DragEvent<HTMLDivElement>) => void;
   onDrop?: () => void;
   isDragging?: boolean;
-  disabled?: boolean; 
+  disabled?: boolean;
 };
 
 export default function QuestionCard({
@@ -32,7 +32,7 @@ export default function QuestionCard({
   onDragOver,
   onDrop,
   isDragging,
-  disabled = false, 
+  disabled = false,
 }: QuestionCardProps) {
   const { token } = theme.useToken();
   const [editing, setEditing] = useState(false);

--- a/client/src/components/ai/QuestionCard.tsx
+++ b/client/src/components/ai/QuestionCard.tsx
@@ -18,6 +18,7 @@ export type QuestionCardProps = {
   onDragOver?: (e: DragEvent<HTMLDivElement>) => void;
   onDrop?: () => void;
   isDragging?: boolean;
+  disabled?: boolean; 
 };
 
 export default function QuestionCard({
@@ -31,6 +32,7 @@ export default function QuestionCard({
   onDragOver,
   onDrop,
   isDragging,
+  disabled = false, 
 }: QuestionCardProps) {
   const { token } = theme.useToken();
   const [editing, setEditing] = useState(false);
@@ -152,7 +154,7 @@ export default function QuestionCard({
             <Space direction="vertical" className="w-full">
               {question.options.map((opt, i) => (
                 <div key={i} className="flex items-center gap-1 px-3 py-1 rounded-md">
-                  <Radio value={`${i}`} />
+                  <Radio value={`${i}`} disabled={disabled} />
                   <Text className="flex-1">{opt}</Text>
                 </div>
               ))}
@@ -164,11 +166,11 @@ export default function QuestionCard({
           <Radio.Group onChange={handleRadio} value={selected} className="w-full">
             <Space direction="vertical" className="w-full">
               <div className="flex items-center gap-1 px-3 py-0 rounded-md">
-                <Radio value="V" />
+                <Radio value="V" disabled={disabled} />
                 <Text className="flex-1">Verdadero</Text>
               </div>
               <div className="flex items-center gap-3 px-3 py-2 rounded-md">
-                <Radio value="F" />
+                <Radio value="F" disabled={disabled} />
                 <Text className="flex-1">Falso</Text>
               </div>
             </Space>

--- a/client/src/pages/exams/AiResults.tsx
+++ b/client/src/pages/exams/AiResults.tsx
@@ -168,6 +168,7 @@ export default function AiResults({
                   question={q}
                   onChange={onChange}
                   onRegenerate={onRegenerateOne}
+                  disabled={q.type === 'multiple_choice' || q.type === 'true_false'}
                 />
               </div>
             ))}


### PR DESCRIPTION
Cambios en AiResults.tsx

Add
Se agregó la prop   |   disabled={q.type === 'multiple_choice' || q.type === 'true_false'}   |   al componente QuestionCard para deshabilitar la selección de respuestas en preguntas de opción múltiple y verdadero/falso.

Update
Ahora, al revisar el examen, las preguntas de tipo "Opción Múltiple" y "Verdadero/Falso" no permiten que el usuario marque una respuesta.
Cambios en QuestionCard.tsx

Add
Se añadió la prop   |   disabled?: boolean   |   al tipo QuestionCardProps y se estableció el valor por defecto en false.
Se agregó la prop   |   disabled={disabled}   |   a los componentes Radio dentro de las preguntas de tipo "Opción Múltiple" y "Verdadero/Falso".

Update
Los inputs de selección (Radio) para preguntas de tipo "Opción Múltiple" y "Verdadero/Falso" ahora respetan la prop disabled, impidiendo la selección cuando corresponde.

Breaking Change
No hay breaking changes: Los cambios son compatibles con el funcionamiento anterior. La prop disabled es opcional y por defecto es false, por lo que no afecta otros usos del componente.

Delete
No se eliminaron funcionalidades ni props existentes.