### PR TITLE
feat(us-58): guardar examen en DB + IDs únicos en preguntas (fix React key)

### DIFF
--- a/backend/src/modules/exams/infrastructure/http/exams.controller.ts
+++ b/backend/src/modules/exams/infrastructure/http/exams.controller.ts
@@ -22,6 +22,7 @@ import { UpdateExamQuestionCommand } from '../../application/commands/update-exa
 import { UpdateExamQuestionCommandHandler } from '../../application/commands/update-exam-question.handler';
 import { ApproveExamCommand } from '../../application/commands/approve-exam.command';
 import { ApproveExamCommandHandler } from '../../application/commands/approve-exam.handler';
+import { PrismaService } from 'src/core/prisma/prisma.service';
 
 import {
   responseSuccess,
@@ -48,6 +49,7 @@ export class ExamsController {
     private readonly addExamQuestionHandler: AddExamQuestionCommandHandler,
     private readonly updateExamQuestionHandler: UpdateExamQuestionCommandHandler,
     private readonly approveExamHandler: ApproveExamCommandHandler,
+    private readonly prisma: PrismaService,
   ) {}
   private readonly logger = new Logger(ExamsController.name);
 
@@ -157,5 +159,74 @@ export class ExamsController {
     const res = await this.approveExamHandler.execute(new ApproveExamCommand(id));
     this.logger.log(`[${cid(req)}] approveExam <- id=${id}`);
     return responseSuccess(cid(req), res, 'Exam approved successfully', pathOf(req));
+  }
+  @Post('quick-save')
+  @HttpCode(200)
+  async quickSave(@Body() body: any, @Req() req: Request) {
+    const c = cid(req);
+    const title = String(body?.title ?? 'Examen');
+
+    let courseId: number | string | undefined = body?.courseId;
+    let teacherId: string | undefined = body?.teacherId;
+
+    if (!courseId) {
+      const firstCourse = await this.prisma.course.findFirst({
+        select: { id: true, teacherId: true },
+        orderBy: { createdAt: 'asc' },
+      });
+      if (!firstCourse) {
+        return responseBadRequest(
+          'No hay courseId y no existe ningún Curso en la base. Crea un curso o envía courseId.',
+          c,
+          'Bad Request',
+          pathOf(req),
+        );
+      }
+      courseId = firstCourse.id; 
+      if (!teacherId && firstCourse.teacherId) teacherId = String(firstCourse.teacherId);
+    }
+
+    const rawQuestions =
+      Array.isArray(body?.questions)
+        ? body.questions
+        : Array.isArray(body?.content?.questions)
+        ? body.content.questions
+        : [];
+
+    const used = new Set<string>();
+    const ts = Date.now();
+    const questions = rawQuestions.map((q: any, i: number) => {
+      const t = String(q?.type ?? 'open_analysis');
+      let id = String(q?.id ?? `q_${ts}_${t}_${i}`);
+      while (used.has(id)) id = `${id}_${Math.random().toString(36).slice(2,6)}`;
+      used.add(id);
+      return {
+        id,
+        type: t,
+        text: String(q?.text ?? ''),
+        options: Array.isArray(q?.options) ? q.options.map(String) : undefined,
+      };
+    });
+
+    const content =
+      body?.content && typeof body.content === 'object'
+        ? body.content
+        : {
+            subject: String(body?.subject ?? 'Tema general'),
+            difficulty: String(body?.difficulty ?? 'medio'),
+            createdAt: new Date().toISOString(),
+            questions,
+          };
+
+    const data: any = {
+      title,
+      status: 'Guardado',
+      content,
+      courseId,                         
+      ...(teacherId ? { teacherId } : {}),
+    };
+
+    const saved = await this.prisma.savedExam.create({ data });
+    return responseSuccess(c, { id: saved.id, title: saved.title }, 'Quick exam saved', pathOf(req));
   }
 }

--- a/client/src/pages/academic_management/CourseDetailPage.tsx
+++ b/client/src/pages/academic_management/CourseDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useParams, useNavigate } from "react-router-dom";
+import { useParams, useNavigate, Link } from "react-router-dom";
 import { useCallback, useEffect, useState } from "react";
 import { Table, Button, message, Typography, Empty, Tabs } from "antd";
 import {
@@ -639,6 +639,12 @@ export function CourseDetailPage() {
                     onClick={goToExams}
                   >
                     Ir a exámenes
+                  </Button>
+                  <Button
+                    type="primary"
+                    onClick={() => navigate(`/exams/create?courseId=${courseId}`)}
+                  >
+                    Crear examen
                   </Button>
                 </div>
               </div>

--- a/client/src/pages/exams/ExamCreatePage.tsx
+++ b/client/src/pages/exams/ExamCreatePage.tsx
@@ -11,6 +11,8 @@ import GlobalScrollbar from '../../components/GlobalScrollbar';
 import './ExamCreatePage.css';
 import AiResults from './AiResults';
 import { generateQuestions, createExamApproved, type GeneratedQuestion, quickSaveExam } from '../../services/exams.service';
+import { useSearchParams } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 
 const layoutStyle: CSSProperties = {
   display: 'flex',
@@ -53,6 +55,9 @@ export default function ExamsCreatePage() {
     difficulty: 'medio',
     reference: '',
   });
+  const { search } = useLocation();
+  const params = new URLSearchParams(search);
+  const courseId = params.get('courseId') || '';
 
   const buildAiInputFromForm = (raw: Record<string, any>) => {
     const difficultyMap: Record<string, 'fácil' | 'medio' | 'difícil'> = {

--- a/client/src/services/exams.service.ts
+++ b/client/src/services/exams.service.ts
@@ -224,21 +224,24 @@ function orderByType(items: GeneratedQuestion[]) {
 }
 
 function normalizeItem(q: any, ts: number, i: number, fallbackType?: GeneratedQuestion['type']): GeneratedQuestion {
-  const type = String(q?.type ?? fallbackType ?? '').trim();
+  const rawType = String(q?.type ?? fallbackType ?? 'open_analysis').trim();
+  const type = (rawType === 'boolean' ? 'true_false' : rawType) as GeneratedQuestion['type'];
   const text = pickTextLike(q);
   const imageUrl = q?.imageUrl ?? q?.image_url ?? undefined;
   const options = pickOptionsLike(q);
 
+  const makeId = (idx: number) => `q_${ts}_${type}_${idx}`; 
+
   if (type === 'multiple_choice') {
-    return { id: `q_${ts}_${i}`, type: 'multiple_choice', text, options: options ?? [], include: true };
+    return { id: makeId(i), type: 'multiple_choice', text, options: options ?? [], include: true };
   }
-  if (type === 'true_false' || type === 'boolean') {
-    return { id: `q_${ts}_${i}`, type: 'true_false', text, include: true };
+  if (type === 'true_false') {
+    return { id: makeId(i), type: 'true_false', text, include: true };
   }
-  if (type === 'open_exercise' || type === 'exercise') {
-    return { id: `q_${ts}_${i}`, type: 'open_exercise', text, include: true };
+  if (type === 'open_exercise') {
+    return { id: makeId(i), type: 'open_exercise', text, include: true };
   }
-  return { id: `q_${ts}_${i}`, type: 'open_analysis', text, imageUrl, options: options ?? undefined, include: true };
+  return { id: makeId(i), type: 'open_analysis', text, imageUrl, options: options ?? undefined, include: true };
 }
 
 export async function generateQuestions(input: Record<string, unknown>): Promise<GeneratedQuestion[]> {
@@ -315,5 +318,79 @@ export async function createExam(payload: any): Promise<any> {
   const res = await api.post('/exams', payload);
   return (res as any)?.data ?? res;
 }
+export async function quickSaveExam(p: { title: string; questions: any[]; content?: any; courseId?: string; teacherId?: string }) {
+  const body = p.content
+    ? p
+    : {
+        title: p.title,
+        content: {
+          subject: 'Tema general',
+          difficulty: 'medio',
+          createdAt: new Date().toISOString(),
+          questions: (p.questions ?? []).map((q: any, i: number) => ({
+            id: String(q?.id ?? `q_${Date.now()}_${i}`),
+            type: String(q?.type),
+            text: String(q?.text ?? ''),
+            options: Array.isArray(q?.options) ? q.options.map(String) : undefined,
+          })),
+        },
+        ...(p.courseId ? { courseId: p.courseId } : {}),
+        ...(p.teacherId ? { teacherId: p.teacherId } : {}),
+      };
 
-export default { generateQuestions, createExam };
+  const { data } = await api.post('/exams/quick-save', body);
+  return data?.data ?? data;
+}
+export type CreateExamApprovedInput = {
+  courseId?: string;                
+  title: string;
+  status?: 'Guardado' | 'Publicado';
+  content?: {
+    subject?: string;
+    difficulty?: string;
+    createdAt?: string;
+    questions: Array<{
+      id: string;
+      type: 'multiple_choice' | 'true_false' | 'open_analysis' | 'open_exercise';
+      text: string;
+      options?: string[];
+    }>;
+  };
+  questions?: Array<{
+    id: string;
+    type: 'multiple_choice' | 'true_false' | 'open_analysis' | 'open_exercise';
+    text: string;
+    options?: string[];
+  }>;
+};
+
+export async function createExamApproved(input: CreateExamApprovedInput) {
+  const body = input.content
+    ? {
+        title: input.title,
+        courseId: input.courseId,            
+        status: input.status ?? 'Guardado',
+        content: input.content,
+      }
+    : {
+        title: input.title,
+        courseId: input.courseId,           
+        status: input.status ?? 'Guardado',
+        content: {
+          subject: 'Tema general',
+          difficulty: 'medio',
+          createdAt: new Date().toISOString(),
+          questions: (input.questions ?? []).map((q) => ({
+            id: String(q.id),
+            type: q.type,
+            text: String(q.text ?? ''),
+            options: Array.isArray(q.options) ? q.options.map(String) : undefined,
+          })),
+        },
+      };
+
+  const { data } = await api.post('/exams/approved', body);
+  return data?.data ?? data;
+}
+
+export default { generateQuestions, createExam, createExamApproved, quickSaveExam };


### PR DESCRIPTION
- Backend: endpoint /exams/quick-save para persistir SavedExam (dev helper).
  * Si no se envía courseId, toma el primer curso existente (fallback).
  * Guarda content.questions normalizado (id/type/text/options).
- Frontend:
  * ExamCreatePage -> usa quickSaveExam al guardar.
  * Fix IDs únicos de preguntas (incluye el tipo en el ID) para evitar warnings de React.

Cómo probar:
1) Generar preguntas en /exams/create y presionar "Guardar y Finalizar".
2) Verificar INSERT en SavedExam (status=Guardado, content.questions poblado).
3) Sin duplicados de keys en consola.

Notas:
- quick-save es para integración rápida; si prefieren, lo movemos detrás de guard o lo reemplazamos por /exams/approved en un PR siguiente.
