### PR TITLE
feat(exams): #85 Contrato y persistencia de `timeMinutes` ∈ [45, 240]

### DIFF
--- a/backend/src/modules/exams/domain/entities/exam.factory.ts
+++ b/backend/src/modules/exams/domain/entities/exam.factory.ts
@@ -24,6 +24,9 @@ export class ExamFactory {
     if (reference && /[<>]/.test(reference)) {
       throw new DomainError('Referencia contiene caracteres no permitidos.');
     }
+    if (props.timeMinutes < 45 || props.timeMinutes > 240) {
+      throw new DomainError('Tiempo (minutos) debe estar entre 45 y 240.');
+    } 
 
     const difficulty = Difficulty.create(props.difficulty);
     const attempts = PositiveInt.create('Intentos', props.attempts);

--- a/backend/src/modules/exams/infrastructure/http/dtos/create-exam.dto.ts
+++ b/backend/src/modules/exams/infrastructure/http/dtos/create-exam.dto.ts
@@ -1,4 +1,4 @@
-import { IsIn, IsInt, IsNotEmpty, IsOptional, IsPositive, IsString, MaxLength, ValidateNested, Min } from 'class-validator';
+import { IsIn, IsInt, IsNotEmpty, IsOptional, IsPositive, IsString, MaxLength, ValidateNested, Min, Max } from 'class-validator';
 import { Type } from 'class-transformer';
 
 class DistributionDto {
@@ -39,7 +39,8 @@ export class CreateExamDto {
   totalQuestions!: number;
 
   @IsInt()
-  @IsPositive({ message: 'Tiempo (minutos) debe ser > 0.' })
+  @Min(45, { message: 'Tiempo (minutos) mínimo: 45.' })
+  @Max(240, { message: 'Tiempo (minutos) máximo: 240.' })
   timeMinutes!: number;
 
   @ValidateNested()


### PR DESCRIPTION
## Criterios de aceptación

### Cuando se hace **POST /exams** con `timeMinutes` dentro del rango (45–240):
- [x] Se guarda el examen exitosamente (200/201).
- [x] La respuesta incluye `timeMinutes` **idéntico** al enviado.
- [x] **GET /exams/:id** devuelve el mismo `timeMinutes` guardado.

### Cuando se hace **POST /exams** con `timeMinutes` fuera del rango:
- [x] Se devuelve **400 Bad Request** con mensaje claro:
  - `< 45` → “Tiempo (minutos) mínimo: 45.”
  - `> 240` → “Tiempo (minutos) máximo: 240.”

### Compatibilidad:
- [x] No se cambian endpoints ni el shape del payload/respuesta.
- [x] No se rompe el frontend (el UI ya restringe 45–240).

---

### Archivos modificados
- `backend/src/modules/exams/infrastructure/http/dtos/create-exam.dto.ts`  
- `backend/src/modules/exams/domain/entities/exam.factory.ts`  

### Cambios realizados
- **`create-exam.dto.ts`**
  - Se añade validación con **class-validator**:
    - `@Min(45, { message: 'Tiempo (minutos) mínimo: 45.' })`
    - `@Max(240, { message: 'Tiempo (minutos) máximo: 240.' })`
  - Se mantiene `@IsInt()`; no se alteran otros campos.

- **`exam.factory.ts`**
  - Se refuerza el invariante de dominio:
    ```ts
    if (props.timeMinutes < 45 || props.timeMinutes > 240) {
      throw new DomainError('Tiempo (minutos) debe estar entre 45 y 240.');
    }
    ```
  - Se conservan las demás validaciones y la construcción del agregado.

---

### Postman

**URL base:** `{{baseUrl}}`  
> Ej.: `http://localhost:3000`

**Endpoints**
- Crear examen: **POST** `{{baseUrl}}/exams`

#### Requests configurados
1. **Create Exam (válido, mínimo 45) — POST `{{baseUrl}}/exams`**  
   **Orden exacto de claves (DTO):**  
   `subject`, `difficulty`, `reference`, `attempts`, `totalQuestions`, `timeMinutes`, `distribution`
   ```json
   {
     "subject": "Matemática I",
     "difficulty": "medio",
     "reference": "Parcial 1 2025",
     "attempts": 1,
     "totalQuestions": 10,
     "timeMinutes": 45,
     "distribution": {
       "multiple_choice": 6,
       "true_false": 2,
       "open_analysis": 1,
       "open_exercise": 1
     }
   }
