### PR TITLE
BACKEND - [#122 y #123] Derive counts + unify correctAnswer (US-136)

### DIFF
--- a/backend/src/modules/exams/application/queries/get-exam-by-id.usecase.ts
+++ b/backend/src/modules/exams/application/queries/get-exam-by-id.usecase.ts
@@ -19,13 +19,14 @@ export class GetExamByIdUseCase {
         }
 
         const questions = await this.questionRepo.listByExamOwned(q.examId, q.teacherId);
+        const counts = await this.questionRepo.countsByExamOwned(q.examId, q.teacherId);
 
         const distribution = exam.distribution
         ? {
-            multiple_choice: exam.mcqCount,
-            true_false: exam.trueFalseCount,
-            open_analysis: exam.openAnalysisCount,
-            open_exercise: exam.openExerciseCount,
+            multiple_choice: counts.mcqCount,
+            true_false: counts.trueFalseCount,
+            open_analysis: counts.openAnalysisCount,
+            open_exercise: counts.openExerciseCount,
             }
         : null;
 
@@ -38,14 +39,14 @@ export class GetExamByIdUseCase {
         subject: exam.subject,
         difficulty: exam.difficulty.getValue ? exam.difficulty.getValue() : exam.difficulty,
         attempts: exam.attempts.getValue ? exam.attempts.getValue() : exam.attempts,
-        totalQuestions: exam.totalQuestions.getValue ? exam.totalQuestions.getValue() : exam.totalQuestions,
+        totalQuestions: counts.totalQuestions,
         timeMinutes: exam.timeMinutes.getValue ? exam.timeMinutes.getValue() : exam.timeMinutes,
         reference: exam.reference,
 
-        mcqCount: exam.mcqCount,
-        trueFalseCount: exam.trueFalseCount,
-        openAnalysisCount: exam.openAnalysisCount,
-        openExerciseCount: exam.openExerciseCount,
+        mcqCount: counts.mcqCount,
+        trueFalseCount: counts.trueFalseCount,
+        openAnalysisCount: counts.openAnalysisCount,
+        openExerciseCount: counts.openExerciseCount,
 
         distribution,
         questions: questions.map(q => ({

--- a/backend/src/modules/exams/application/queries/get-exam-by-id.usecase.ts
+++ b/backend/src/modules/exams/application/queries/get-exam-by-id.usecase.ts
@@ -29,6 +29,11 @@ export class GetExamByIdUseCase {
             open_exercise: counts.openExerciseCount,
             }
         : null;
+        const toCorrectAnswer = (q: any): boolean | number | null => {
+            if (q.kind === 'MULTIPLE_CHOICE') return Number.isInteger(q.correctOptionIndex) ? q.correctOptionIndex : null;
+            if (q.kind === 'TRUE_FALSE') return typeof q.correctBoolean === 'boolean' ? q.correctBoolean : null;
+            return null; 
+        };
 
         return {
         id: exam.id,
@@ -54,6 +59,7 @@ export class GetExamByIdUseCase {
             kind: q.kind,                // MULTIPLE_CHOICE | TRUE_FALSE | OPEN_ANALYSIS | OPEN_EXERCISE
             text: q.text,
             options: q.options ?? null,
+            correctAnswer: toCorrectAnswer(q),
             correctOptionIndex: q.correctOptionIndex ?? null,
             correctBoolean: q.correctBoolean ?? null,
             expectedAnswer: q.expectedAnswer ?? null,

--- a/backend/src/modules/exams/domain/ports/exam-question.repository.port.ts
+++ b/backend/src/modules/exams/domain/ports/exam-question.repository.port.ts
@@ -4,16 +4,30 @@ export type InsertPosition = 'start' | 'middle' | 'end';
 
 export type UpdateExamQuestionPatch = {
   text?: string;
-  options?: string[];
-  correctOptionIndex?: number;
-  correctBoolean?: boolean;
-  expectedAnswer?: string;
+  options?: any[] | null;
+  correctOptionIndex?: number | null;
+  correctBoolean?: boolean | null;
+  expectedAnswer?: string | null;
+};
+
+export type DerivedCounts = {
+  totalQuestions: number;
+  mcqCount: number;
+  trueFalseCount: number;
+  openAnalysisCount: number;
+  openExerciseCount: number;
 };
 
 export interface ExamQuestionRepositoryPort {
   existsExamOwned(examId: string, teacherId: string): Promise<boolean>;
 
   countByExamOwned(examId: string, teacherId: string): Promise<number>;
+  countsByExamOwned(examId: string, teacherId: string): Promise<DerivedCounts>;
+
+  bulkCountsByExamIdsOwned(
+    examIds: string[],
+    teacherId: string,
+  ): Promise<Map<string, DerivedCounts>>;
 
   addToExamOwned(
     examId: string,

--- a/backend/src/modules/exams/infrastructure/http/dtos/add-exam-question.dto.ts
+++ b/backend/src/modules/exams/infrastructure/http/dtos/add-exam-question.dto.ts
@@ -1,4 +1,4 @@
-import { IsArray, IsBoolean, IsEnum, IsIn, IsInt, IsNotEmpty, IsOptional, IsString, MaxLength, Min } from 'class-validator';
+import { IsArray, IsBoolean, IsEnum, IsIn, IsInt, IsNotEmpty, IsOptional, IsString, MaxLength, Min, ValidateIf } from 'class-validator';
 
 export class AddExamQuestionDto {
   @IsEnum(['MULTIPLE_CHOICE','TRUE_FALSE','OPEN_ANALYSIS','OPEN_EXERCISE'] as any)
@@ -24,4 +24,14 @@ export class AddExamQuestionDto {
 
   @IsIn(['start','middle','end'])
   position!: 'start'|'middle'|'end';
+
+  @IsOptional()
+  @ValidateIf(o => o.kind === 'MULTIPLE_CHOICE')
+  @IsInt()
+  @Min(0)
+  @ValidateIf(o => o.kind === 'TRUE_FALSE')
+  @IsBoolean()
+  @ValidateIf(o => o.kind === 'OPEN_ANALYSIS' || o.kind === 'OPEN_EXERCISE')
+  @IsIn([null], { message: 'correctAnswer debe ser null para preguntas abiertas.' })
+  correctAnswer?: number | boolean | null;
 }

--- a/backend/src/modules/exams/infrastructure/http/dtos/update-exam-question.dto.ts
+++ b/backend/src/modules/exams/infrastructure/http/dtos/update-exam-question.dto.ts
@@ -1,18 +1,35 @@
-import { IsArray, IsBoolean, IsInt, IsOptional, IsString, MaxLength, Min } from 'class-validator';
+import { IsArray, IsBoolean, IsEnum, IsIn, IsInt, IsOptional, IsString, MaxLength, Min, ValidateIf } from 'class-validator';
 
 export class UpdateExamQuestionDto {
-    @IsOptional() @IsString() @MaxLength(4000)
-    text?: string;
+  @IsEnum(['MULTIPLE_CHOICE','TRUE_FALSE','OPEN_ANALYSIS','OPEN_EXERCISE'] as any)
+  kind!: 'MULTIPLE_CHOICE'|'TRUE_FALSE'|'OPEN_ANALYSIS'|'OPEN_EXERCISE';
 
-    @IsOptional() @IsArray()
-    options?: string[];
+  // PATCH: todo opcional
+  @IsOptional() @IsString() @MaxLength(4000)
+  text?: string;
 
-    @IsOptional() @IsInt() @Min(0)
-    correctOptionIndex?: number;
+  // MCQ
+  @IsOptional() @IsArray()
+  options?: string[];
 
-    @IsOptional() @IsBoolean()
-    correctBoolean?: boolean;
+  @IsOptional() @IsInt() @Min(0)
+  correctOptionIndex?: number;
 
-    @IsOptional() @IsString()
-    expectedAnswer?: string;
+  // TRUE_FALSE
+  @IsOptional() @IsBoolean()
+  correctBoolean?: boolean;
+
+  // OPEN_*
+  @IsOptional() @IsString()
+  expectedAnswer?: string;
+
+  @IsOptional()
+    @ValidateIf(o => o.kind === 'MULTIPLE_CHOICE')
+    @IsInt()
+    @Min(0)
+    @ValidateIf(o => o.kind === 'TRUE_FALSE')
+    @IsBoolean({ message: 'correctAnswer debe ser boolean.' })
+    @ValidateIf(o => o.kind === 'OPEN_ANALYSIS' || o.kind === 'OPEN_EXERCISE')
+    @IsIn([null], { message: 'correctAnswer debe ser null para preguntas abiertas.' })
+    correctAnswer?: number | boolean | null;
 }

--- a/backend/src/modules/exams/infrastructure/persistence/exam-question.prisma.repository.ts
+++ b/backend/src/modules/exams/infrastructure/persistence/exam-question.prisma.repository.ts
@@ -3,6 +3,7 @@ import { PrismaService } from '../../../../core/prisma/prisma.service';
 import type {
   ExamQuestionRepositoryPort,
   UpdateExamQuestionPatch,
+  DerivedCounts,
 } from '../../domain/ports/exam-question.repository.port';
 import { ExamQuestion, NewExamQuestion } from '../../domain/entities/exam-question.entity';
 import { Prisma } from '@prisma/client'; 
@@ -25,22 +26,33 @@ const map = (q: any): ExamQuestion => ({
 export class ExamQuestionPrismaRepository implements ExamQuestionRepositoryPort {
   constructor(private readonly prisma: PrismaService) {}
 
+  private async isExamOwnedByTeacher(examId: string, teacherId: string): Promise<boolean> {
+    const rows = await this.prisma.$queryRaw<Array<{ ok: number }>>`
+      SELECT 1 AS ok
+      FROM "Exam" e
+      JOIN "Classes" c ON c."id" = e."classId"
+      JOIN "Course"  cr ON cr."id" = c."courseId"
+      WHERE e."id" = ${examId} AND cr."teacherId" = ${teacherId}
+      LIMIT 1
+    `;
+    return rows.length > 0;
+  }
+
   async existsExamOwned(examId: string, teacherId: string): Promise<boolean> {
-    const count = await this.prisma.exam.count({
-      where: { id: examId, class: { is: { course: { teacherId } } } }, 
-    });
-    return count > 0;
+    return this.isExamOwnedByTeacher(examId, teacherId);
   }
 
   async countByExamOwned(examId: string, teacherId: string): Promise<number> {
-    return this.prisma.examQuestion.count({
-      where: { examId, exam: { is: { class: { is: { course: { teacherId } } } } } }, 
-    });
+    const owned = await this.isExamOwnedByTeacher(examId, teacherId);
+    if (!owned) return 0;
+    return this.prisma.examQuestion.count({ where: { examId } });
   }
 
   async listByExamOwned(examId: string, teacherId: string) {
+    const owned = await this.isExamOwnedByTeacher(examId, teacherId);
+    if (!owned) return [];
     const rows = await this.prisma.examQuestion.findMany({
-      where: { examId, exam: { is: { class: { is: { course: { teacherId } } } } } },
+      where: { examId },
       orderBy: { order: 'asc' },
     });
     return rows.map(map);
@@ -52,19 +64,20 @@ export class ExamQuestionPrismaRepository implements ExamQuestionRepositoryPort 
     q: NewExamQuestion,
     position: 'start' | 'middle' | 'end',
   ): Promise<ExamQuestion> {
-    const owned = await this.existsExamOwned(examId, teacherId);
+    const owned = await this.isExamOwnedByTeacher(examId, teacherId);
     if (!owned) throw new Error('Examen no encontrado o acceso no autorizado');
 
-    const count = await this.countByExamOwned(examId, teacherId);
+    const count = await this.prisma.examQuestion.count({ where: { examId } });
     let newOrder = count;
     if (position === 'start') newOrder = 0;
     else if (position === 'middle') newOrder = Math.floor(count / 2);
 
     if (position !== 'end') {
-      await this.prisma.$executeRawUnsafe(
-        `UPDATE "ExamQuestion" SET "order" = "order" + 1 WHERE "examId" = $1`,
-        examId,
-      );
+      await this.prisma.$executeRaw`
+        UPDATE "ExamQuestion"
+        SET "order" = "order" + 1
+        WHERE "examId" = ${examId} AND "order" >= ${newOrder}
+      `;
     }
 
     const data: Parameters<typeof this.prisma.examQuestion.create>[0]['data'] = {
@@ -85,15 +98,27 @@ export class ExamQuestionPrismaRepository implements ExamQuestionRepositoryPort 
   }
 
   async findByIdOwned(id: string, teacherId: string) {
-    const row = await this.prisma.examQuestion.findFirst({
-      where: { id, exam: { is: { class: { is: { course: { teacherId } } } } } },
-    });
-    return row ? map(row) : null;
+    const row = await this.prisma.examQuestion.findUnique({ where: { id } });
+    if (!row) return null;
+
+    const owned = await this.isExamOwnedByTeacher(row.examId, teacherId);
+    if (!owned) return null;
+
+    return map(row);
   }
 
   async updateOwned(id: string, teacherId: string, patch: UpdateExamQuestionPatch) {
-    await this.prisma.examQuestion.updateMany({
-      where: { id, exam: { is: { class: { is: { course: { teacherId } } } } } },
+    const current = await this.prisma.examQuestion.findUnique({
+      where: { id },
+      select: { examId: true },
+    });
+    if (!current) throw new Error('Pregunta no encontrada o acceso no autorizado');
+
+    const owned = await this.isExamOwnedByTeacher(current.examId, teacherId);
+    if (!owned) throw new Error('Pregunta no encontrada o acceso no autorizado');
+
+    await this.prisma.examQuestion.update({
+      where: { id },
       data: {
         ...(patch.text !== undefined ? { text: patch.text } : {}),
         ...(patch.options !== undefined
@@ -105,10 +130,66 @@ export class ExamQuestionPrismaRepository implements ExamQuestionRepositoryPort 
       },
     });
 
-    const row = await this.prisma.examQuestion.findFirst({
-      where: { id, exam: { is: { class: { is: { course: { teacherId } } } } } },
-    });
+    const row = await this.prisma.examQuestion.findUnique({ where: { id } });
     if (!row) throw new Error('Pregunta no encontrada o acceso no autorizado');
     return map(row);
+  }
+
+  async countsByExamOwned(examId: string, teacherId: string): Promise<DerivedCounts> {
+    const rows = await this.prisma.$queryRaw<Array<{ kind: string; count: number }>>`
+      SELECT q."kind", COUNT(*)::int AS count
+      FROM "ExamQuestion" q
+      JOIN "Exam"     e  ON e."id"      = q."examId"
+      JOIN "Classes"  c  ON c."id"      = e."classId"
+      JOIN "Course"   cr ON cr."id"     = c."courseId"
+      WHERE q."examId" = ${examId} AND cr."teacherId" = ${teacherId}
+      GROUP BY q."kind"
+    `;
+    const get = (k: string) => rows.find(r => r.kind === k)?.count ?? 0;
+    const total = rows.reduce((s, r) => s + r.count, 0);
+    return {
+      totalQuestions: total,
+      mcqCount: get('MULTIPLE_CHOICE'),
+      trueFalseCount: get('TRUE_FALSE'),
+      openAnalysisCount: get('OPEN_ANALYSIS'),
+      openExerciseCount: get('OPEN_EXERCISE'),
+    };
+  }
+
+  async bulkCountsByExamIdsOwned(
+    examIds: string[],
+    teacherId: string,
+  ): Promise<Map<string, DerivedCounts>> {
+    const acc = new Map<string, DerivedCounts>();
+    if (examIds.length === 0) return acc;
+
+    const rows = await this.prisma.$queryRaw<Array<{ examId: string; kind: string; count: number }>>`
+      SELECT q."examId", q."kind", COUNT(*)::int AS count
+      FROM "ExamQuestion" q
+      JOIN "Exam"     e  ON e."id"      = q."examId"
+      JOIN "Classes"  c  ON c."id"      = e."classId"
+      JOIN "Course"   cr ON cr."id"     = c."courseId"
+      WHERE q."examId" IN (${Prisma.join(examIds)}) AND cr."teacherId" = ${teacherId}
+      GROUP BY q."examId", q."kind"
+    `;
+
+    for (const { examId, kind, count } of rows) {
+      const cur = acc.get(examId) ?? {
+        totalQuestions: 0, mcqCount: 0, trueFalseCount: 0, openAnalysisCount: 0, openExerciseCount: 0,
+      };
+      cur.totalQuestions += count;
+      if (kind === 'MULTIPLE_CHOICE') cur.mcqCount += count;
+      else if (kind === 'TRUE_FALSE') cur.trueFalseCount += count;
+      else if (kind === 'OPEN_ANALYSIS') cur.openAnalysisCount += count;
+      else if (kind === 'OPEN_EXERCISE') cur.openExerciseCount += count;
+      acc.set(examId, cur);
+    }
+
+    for (const id of examIds) {
+      if (!acc.has(id)) {
+        acc.set(id, { totalQuestions: 0, mcqCount: 0, trueFalseCount: 0, openAnalysisCount: 0, openExerciseCount: 0 });
+      }
+    }
+    return acc;
   }
 }

--- a/backend/src/modules/exams/infrastructure/persistence/exam-question.prisma.repository.ts
+++ b/backend/src/modules/exams/infrastructure/persistence/exam-question.prisma.repository.ts
@@ -110,19 +110,45 @@ export class ExamQuestionPrismaRepository implements ExamQuestionRepositoryPort 
   async updateOwned(id: string, teacherId: string, patch: UpdateExamQuestionPatch) {
     const current = await this.prisma.examQuestion.findUnique({
       where: { id },
-      select: { examId: true },
+      select: { examId: true, kind: true, options: true },
     });
     if (!current) throw new Error('Pregunta no encontrada o acceso no autorizado');
 
     const owned = await this.isExamOwnedByTeacher(current.examId, teacherId);
     if (!owned) throw new Error('Pregunta no encontrada o acceso no autorizado');
 
+    const kind = current.kind;
+    const newOptions = patch.options ?? (current.options as any[] | null);
+
+    if (kind === 'MULTIPLE_CHOICE') {
+      if (patch.correctOptionIndex != null) {
+        if (!Number.isInteger(patch.correctOptionIndex)) {
+          throw new Error('correctAnswer inválido: se esperaba un índice entero para MULTIPLE_CHOICE.');
+        }
+        if (!Array.isArray(newOptions) || patch.correctOptionIndex < 0 || patch.correctOptionIndex >= newOptions.length) {
+          throw new Error('correctAnswer fuera de rango: índice no corresponde a options.');
+        }
+      }
+    } else if (kind === 'TRUE_FALSE') {
+      if (patch.correctBoolean != null && typeof patch.correctBoolean !== 'boolean') {
+        throw new Error('correctAnswer inválido: se esperaba boolean para TRUE_FALSE.');
+      }
+    } else { // OPEN_*
+      if (patch.expectedAnswer != null) {
+      }
+    }
+
     await this.prisma.examQuestion.update({
       where: { id },
       data: {
         ...(patch.text !== undefined ? { text: patch.text } : {}),
         ...(patch.options !== undefined
-          ? { options: patch.options === null ? Prisma.JsonNull : (patch.options as unknown as Prisma.InputJsonValue) }
+          ? {
+              options:
+                patch.options === null
+                  ? Prisma.JsonNull
+                  : (patch.options as unknown as Prisma.InputJsonValue),
+            }
           : {}),
         ...(patch.correctOptionIndex !== undefined ? { correctOptionIndex: patch.correctOptionIndex } : {}),
         ...(patch.correctBoolean !== undefined ? { correctBoolean: patch.correctBoolean } : {}),


### PR DESCRIPTION
## Criterios de aceptación 
### Caso feliz / principal
- [x] **GET `/api/exams/{examId}`** calcula y devuelve `totalQuestions`, `mcqCount`, `trueFalseCount`, `openAnalysisCount`, `openExerciseCount` **derivados** desde `ExamQuestion`.
- [x] **POST** (agregar preguntas) se refleja en el siguiente **GET** (los totales coinciden con `questions[]`).
- [x] **PUT** (editar pregunta sin cambiar tipo) mantiene los totales correctos en el siguiente **GET**.

### Casos de error / alternos
- [x] **401 Unauthorized**: sin token o token inválido.
- [x] **403 Forbidden**: `teacherId` del token no es dueño del `examId`/`classId`.
- [x] **400 Bad Request**: body inválido (p.ej., MCQ sin opciones o `correctOptionIndex` fuera de rango).

---

## Archivos modificados
- `backend/src/modules/exams/application/queries/get-exam-by-id.usecase.ts`  
- `backend/src/modules/exams/domain/ports/exam-question.repository.port.ts`  
- `backend/src/modules/exams/infrastructure/persistence/exam-question.prisma.repository.ts`  

---

## Cambios realizados
- **`get-exam-by-id.usecase.ts`**
  - Obtiene `questions` del examen y **sustituye** los campos denormalizados por los **conteos derivados** retornados por el repositorio (`countsByExamOwned`).
  - Mantiene el mismo **schema** de respuesta para compatibilidad (totales + arreglo `questions[]`).

- **`exam-question.repository.port.ts`**
  - Se define el tipo:
    ```ts
    export type DerivedCounts = {
      totalQuestions: number;
      mcqCount: number;
      trueFalseCount: number;
      openAnalysisCount: number;
      openExerciseCount: number;
    };
    ```
  - Se agregan firmas:
    - `countsByExamOwned(examId: string, teacherId: string): Promise<DerivedCounts>`
    - `bulkCountsByExamIdsOwned(examIds: string[], teacherId: string): Promise<Map<string, DerivedCounts>>`

- **`exam-question.prisma.repository.ts`**
  - Validación de **ownership** por `teacherId` (join `Exam` → `Classes` → `Course`).
  - Implementación de **conteos derivados** con `GROUP BY kind`:
    - `totalQuestions`, `mcqCount`, `trueFalseCount`, `openAnalysisCount`, `openExerciseCount`.
  - Inserción de preguntas conserva orden y tipado (`JSON` para options, `Prisma.JsonNull` cuando corresponde).
  - `findByIdOwned`/`updateOwned`: respetan ownership y devuelven entidad mapeada.

---

## Postman

**URL base**: `{{baseUrl}}` (ej. `http://localhost:3000`)  
**Auth**: `Authorization: Bearer {{token}}`  
**Headers**: `Content-Type: application/json`

> **Pre-request** (colección/carpeta) — generar `{{token}}` con `sub = {{teacherId}}`:
```js
function b64url(o){return Buffer.from(JSON.stringify(o),'utf8').toString('base64').replace(/=/g,'').replace(/\+/g,'-').replace(/\//g,'_');}
const header  = b64url({ alg:"none", typ:"JWT" });
const payload = b64url({ sub: pm.environment.get("teacherId") });
pm.environment.set("token", `${header}.${payload}.`);
```
---
## Variables de Environment sugeridas
```
baseUrl = http://localhost:3000
teacherId = <UUID del docente>
classId = <UUID de la clase del docente>
examId =
questionId =
token =
```
## Requests configurados
Crear examen
POST {{baseUrl}}/api/exams
Body:
```
{
  "title": "Parcial #122",
  "classId": "{{classId}}",
  "subject": "Algoritmos",
  "difficulty": "medio",
  "attempts": 1,
  "totalQuestions": 10,
  "timeMinutes": 60,
  "distribution": {
    "multiple_choice": 5,
    "true_false": 5,
    "open_analysis": 0,
    "open_exercise": 0
  }
}
```
> Esperado: '{ "code": 200, "data": { "id": "<examId>", ... } }'
> Tests (Post-res):
```
const r = pm.response.json();
pm.environment.set("examId", r.data.id);
```
---