### PR TITLE
feat(exams-backend): #154 Lectura fiel, #155 Guardar ediciones y #156 Exportar con datos frescos

### DIFF
--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -11,7 +11,7 @@ async function bootstrap() {
   app.use(express.json({ limit: '100mb' }));
   app.use(express.urlencoded({ limit: '100mb', extended: true }));
 
-  app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true, forbidNonWhitelisted: true, transformOptions: { enableImplicitConversion: true } }));
+  app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
   app.useGlobalFilters(new DomainErrorFilter()); 
 
   app.enableShutdownHooks();

--- a/backend/src/modules/exams/domain/ports/exam-question.repository.port.ts
+++ b/backend/src/modules/exams/domain/ports/exam-question.repository.port.ts
@@ -8,6 +8,7 @@ export type UpdateExamQuestionPatch = {
   correctOptionIndex?: number | null;
   correctBoolean?: boolean | null;
   expectedAnswer?: string | null;
+  order?: number | null;
 };
 
 export type DerivedCounts = {

--- a/backend/src/modules/exams/infrastructure/http/dtos/update-exam-question.dto.ts
+++ b/backend/src/modules/exams/infrastructure/http/dtos/update-exam-question.dto.ts
@@ -23,6 +23,9 @@ export class UpdateExamQuestionDto {
   @IsOptional() @IsString()
   expectedAnswer?: string;
 
+  @IsOptional() @IsInt() @Min(0)
+  order?: number;
+
   @IsOptional()
     @ValidateIf(o => o.kind === 'MULTIPLE_CHOICE')
     @IsInt()

--- a/backend/src/modules/exams/infrastructure/http/exams.controller.ts
+++ b/backend/src/modules/exams/infrastructure/http/exams.controller.ts
@@ -370,6 +370,7 @@ export class ExamsController {
       correctOptionIndex: norm.correctOptionIndex ?? undefined,
       correctBoolean: norm.correctBoolean ?? undefined,
       expectedAnswer: norm.expectedAnswer ?? undefined,
+      order: dto.order ?? undefined,
     });
 
     const updated = await this.updateExamQuestionHandler.execute(cmd);

--- a/backend/src/modules/exams/infrastructure/persistence/exam-question.prisma.repository.ts
+++ b/backend/src/modules/exams/infrastructure/persistence/exam-question.prisma.repository.ts
@@ -286,6 +286,34 @@ export class PrismaExamQuestionRepository implements ExamQuestionRepositoryPort 
       });
       if (!current) throw new Error('Question not found or not owned by teacher.');
 
+      if (patch.order != null && Number.isFinite(patch.order)) {
+        const newOrder = Math.max(0, Math.trunc(patch.order as number));
+        if (newOrder !== current.order) {
+          const maxAgg = await tx.examQuestion.aggregate({
+            where: { examId: current.examId },
+            _max: { order: true },
+          });
+          const maxOrder = maxAgg._max.order ?? 0;
+          const target = Math.min(newOrder, maxOrder);
+
+          if (target < current.order) {
+            await tx.examQuestion.updateMany({
+              where: { examId: current.examId, order: { gte: target, lt: current.order } },
+              data: { order: { increment: 1 } },
+            });
+          } else {
+            await tx.examQuestion.updateMany({
+              where: { examId: current.examId, order: { gt: current.order, lte: target } },
+              data: { order: { decrement: 1 } },
+            });
+          }
+          await tx.examQuestion.update({
+            where: { id },
+            data: { order: target },
+          });
+        }
+      }
+
       if (patch.text !== undefined) {
         await tx.examQuestion.update({
           where: { id },

--- a/backend/src/modules/exams/infrastructure/persistence/exam.prisma.repository.ts
+++ b/backend/src/modules/exams/infrastructure/persistence/exam.prisma.repository.ts
@@ -69,7 +69,7 @@ export class PrismaExamRepository implements ExamRepositoryPort {
         classId,
         class: { course: { teacherId } },
       },
-      orderBy: [{ createdAt: 'desc' }],
+      orderBy: [{ updatedAt: 'desc' }],
     });
 
     return rows.map((r) =>

--- a/backend/src/modules/llm/infrastructure/adapters/openai.adapter.ts
+++ b/backend/src/modules/llm/infrastructure/adapters/openai.adapter.ts
@@ -1,0 +1,146 @@
+import { Injectable } from '@nestjs/common';
+import { LlmPort, LlmGenOptions, LlmTextOutput, LlmMessage, } from '../../domain/ports/llm.port';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+
+type ChatChoice = {
+  index: number;
+  finish_reason?: string;
+  message?: { role: string; content?: string | Array<{ type: string; text?: string }> };
+};
+
+@Injectable()
+export class OpenAiAdapter implements LlmPort {
+  private readonly apiKey: string;
+  private readonly baseUrl: string;
+  private readonly defaultTimeoutMs: number;
+  private readonly templatesDir: string;
+
+  constructor() {
+    this.apiKey = process.env.OPENAI_API_KEY!;
+    if (!this.apiKey) throw new Error('OPENAI_API_KEY is required');
+    this.baseUrl = process.env.OPENAI_BASE_URL ?? 'https://api.openai.com/v1';
+    this.defaultTimeoutMs = Number(process.env.OPENAI_TIMEOUT_MS ?? 20000);
+    this.templatesDir = path.resolve(process.cwd(), process.env.PROMPT_TPL_DIR ?? 'templates');
+  }
+
+  private pickModel(options?: LlmGenOptions) {
+    return (
+      options?.model?.name ||
+      process.env.LLM_MODEL ||
+      process.env.AI_MODEL ||
+      'gpt-4o-mini'
+    );
+  }
+  private pickTemp(options?: LlmGenOptions) {
+    return options?.temperature ?? Number(process.env.AI_TEMPERATURE ?? 0.2);
+  }
+  private pickMax(options?: LlmGenOptions) {
+    return options?.maxTokens ?? Number(process.env.AI_MAX_OUTPUT_TOKENS ?? 1024);
+  }
+
+  private async request(pathname: string, body: any, timeoutMs?: number) {
+    const ctrl = new AbortController();
+    const id = setTimeout(() => ctrl.abort(), timeoutMs ?? this.defaultTimeoutMs);
+    try {
+      const res = await fetch(`${this.baseUrl}${pathname}`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${this.apiKey}`,
+        },
+        body: JSON.stringify(body),
+        signal: ctrl.signal,
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        const msg =
+          typeof data?.error?.message === 'string'
+            ? data.error.message.slice(0, 300)
+            : `HTTP ${res.status}`;
+        throw new Error(`OpenAI error: ${msg}`);
+      }
+      return data;
+    } finally {
+      clearTimeout(id);
+    }
+  }
+
+  private extractText(data: any): string {
+    const choice: ChatChoice | undefined = data?.choices?.[0];
+    const c = choice?.message?.content;
+    if (typeof c === 'string') return c;
+    if (Array.isArray(c)) {
+      const part = c.find((p) => p?.type === 'text');
+      if (part?.text) return String(part.text);
+    }
+    return '';
+  }
+
+  async complete(prompt: string, options: LlmGenOptions): Promise<LlmTextOutput> {
+    const body = {
+      model: this.pickModel(options),
+      messages: [{ role: 'user', content: prompt }],
+      temperature: this.pickTemp(options),
+      max_tokens: this.pickMax(options),
+      ...(((options as any)?.vendorOptions?.response_format === 'json') && {
+        response_format: { type: 'json_object' },
+      }),
+    };
+
+    const data = await this.request('/chat/completions', body, (options as any)?.timeoutMs);
+    const text = this.extractText(data);
+    const total = data?.usage?.total_tokens;
+    return { text, tokens: { total }, raw: data };
+  }
+
+  async chat(messages: LlmMessage[], options: LlmGenOptions): Promise<LlmTextOutput> {
+    const mapped = messages.map((m) => ({ role: m.role, content: m.content }));
+    const body = {
+      model: this.pickModel(options),
+      messages: mapped,
+      temperature: this.pickTemp(options),
+      max_tokens: this.pickMax(options),
+      ...(((options as any)?.vendorOptions?.response_format === 'json') && {
+        response_format: { type: 'json_object' },
+      }),
+    };
+
+    const data = await this.request('/chat/completions', body, (options as any)?.timeoutMs);
+    const text = this.extractText(data);
+    const total = data?.usage?.total_tokens;
+    return { text, tokens: { total }, raw: data };
+  }
+
+  async embed(texts: string[]): Promise<number[][]> {
+    const input =
+      Array.isArray(texts) && texts.length > 1 ? texts : [Array.isArray(texts) ? texts[0] : String(texts)];
+    const body = {
+      model: process.env.OPENAI_EMBEDDING_MODEL ?? 'text-embedding-3-small',
+      input,
+    };
+    const data = await this.request('/embeddings', body);
+    const vectors = Array.isArray(data?.data) ? data.data.map((d: any) => d?.embedding ?? []) : [[]];
+    return vectors;
+  }
+
+  async stream?(messages: LlmMessage[] | string, options: LlmGenOptions, onToken: (t: string) => void) {
+    const res = await this.chat(
+      Array.isArray(messages) ? messages : [{ role: 'user', content: String(messages) }],
+      options
+    );
+    onToken?.(res.text);
+    return res;
+  }
+
+  async getChatPrompt(userQuestion: string): Promise<string> {
+    const templatePath = path.join(this.templatesDir, 'singleQuestion.v1.md');
+    const template = await fs.readFile(templatePath, 'utf8').catch(() => '{{user_question}}');
+    return template.replace('{{user_question}}', userQuestion);
+  }
+
+  async askChatQuestion(userQuestion: string, options: LlmGenOptions) {
+    const prompt = await this.getChatPrompt(userQuestion);
+    return this.complete(prompt, options);
+  }
+}

--- a/backend/src/modules/llm/llm.module.ts
+++ b/backend/src/modules/llm/llm.module.ts
@@ -6,14 +6,17 @@ const implProvider = {
   provide: LLM_PORT,
   useClass: (() => {
     const provider = process.env.LLM_PROVIDER?.toLowerCase();
-    // if (provider === 'openai') {
-    //   return require('@/modules/llm-openai/infrastructure/openai.adapter')
-    //     .OpenAiAdapter;
-    // }
-    if (provider === 'gemini') {
-      return require('../llm/infrastructure/adapters/gemini.adapter')
-        .GeminiAdapter;
+
+    if (provider === 'openai') {
+      return require('./infrastructure/adapters/openai.adapter')
+        .OpenAiAdapter;
     }
+
+    // (opcional, si quieres dejar gemini activo por env)
+    // if (provider === 'gemini') {
+    //   return require('./infrastructure/adapters/gemini.adapter')
+    //     .GeminiAdapter;
+    // }
 
     return OllamaAdapter;
   })(),

--- a/client/src/components/exams/ExamForm.tsx
+++ b/client/src/components/exams/ExamForm.tsx
@@ -293,7 +293,7 @@ export const ExamForm = forwardRef<ExamFormHandle, Props>(function ExamForm(
             <>
               <div className="form-group sm:col-span-2">
                 <label htmlFor="subject" className="block text-sm font-medium mb-1">
-                  Materia
+                  Titulo del examen
                 </label>
                 <input
                   id="subject"
@@ -307,7 +307,7 @@ export const ExamForm = forwardRef<ExamFormHandle, Props>(function ExamForm(
                     outline-none transition
                     focus:ring-2
                   "
-                  placeholder="Ej: Algorítmica 1"
+                  placeholder="Ej: 1er parcial"
                   value={values.subject || ''}
                   onChange={(e) => onChange('subject', e.target.value)}
                   autoComplete="off"

--- a/client/src/pages/exams/ExamCreatePage.tsx
+++ b/client/src/pages/exams/ExamCreatePage.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useRef, useState, useEffect } from 'react';
 import type { CSSProperties } from 'react';
 import '../../components/exams/ExamForm.css';
 import '../../components/shared/Toast.css';
@@ -11,6 +11,7 @@ import GlobalScrollbar from '../../components/GlobalScrollbar';
 import './ExamCreatePage.css';
 import { generateQuestions, createExamApproved, updateExamApprovedFull,type GeneratedQuestion } from '../../services/exams.service';
 import AiResults from './AiResults';
+import { getExamById, snapshotHash } from '../../services/exams.service';
 import { normalizeToQuestions, cloneQuestion, replaceQuestion, reorderQuestions } from './ai-utils';
 import { isValidGeneratedQuestion } from '../../utils/aiValidation';
 import { useNavigate, useSearchParams, useLocation } from 'react-router-dom';
@@ -84,6 +85,40 @@ export default function ExamsCreatePage() {
     reference: editData?.reference || ''
   });
 
+  useEffect(() => {
+    try {
+      const storedId = readJSON<string>('exam:lastSavedId') || editData?.id;
+      if (!storedId) return;
+      (async () => {
+        try {
+          const be = await getExamById(storedId);
+          setAiMeta({
+            subject: be.subject || 'Tema general',
+            difficulty: be.difficulty || 'medio',
+            reference: '',
+          });
+          const qs = (be.questions || []).map((q, i) => ({
+            ...q,
+            include: q.include !== false,
+            id: q.id || `${q.type}_${i}`,
+          }));
+          setAiQuestions(qs);
+          const hash = snapshotHash({
+            title: be.title,
+            subject: be.subject,
+            difficulty: be.difficulty,
+            questions: qs,
+          });
+          localStorage.setItem('exam:lastSavedId', storedId);
+          localStorage.setItem(`exam:snapshotHash:${storedId}`, hash);
+          localStorage.setItem(`exam:dirty:${storedId}`, '0');
+        } catch (err) {
+          console.warn('[Editor Refresh] No se pudo hidratar desde BE, se mantiene estado local.', err);
+        }
+      })();
+    } catch {}
+  }, []);
+
   const buildAiInputFromForm = (raw: Record<string, any>) => {
     const difficultyMap: Record<string, 'fácil' | 'medio' | 'difícil'> = {
       facil: 'fácil', 'fácil': 'fácil', easy: 'fácil',
@@ -152,11 +187,33 @@ export default function ExamsCreatePage() {
   };
 
   const onChangeQuestion = (q: GeneratedQuestion) => {
-    setAiQuestions(prev => replaceQuestion(prev, q));
+    setAiQuestions(prev => {
+      const next = replaceQuestion(prev, q);
+      try {
+        const id = readJSON<string>('exam:lastSavedId') || editData?.id;
+        if (id) {
+          const h = snapshotHash({ title: aiMeta?.subject || 'Examen', subject: aiMeta?.subject, difficulty: aiMeta?.difficulty, questions: next });
+          const base = localStorage.getItem(`exam:snapshotHash:${id}`) || '';
+          localStorage.setItem(`exam:dirty:${id}`, h !== base ? '1' : '0');
+        }
+      } catch {}
+      return next;
+    });
   };
 
   const onReorderQuestion = (from: number, to: number) => {
-    setAiQuestions(prev => reorderQuestions(prev, from, to));
+    setAiQuestions(prev => { 
+      const next = reorderQuestions(prev, from, to); 
+      try { 
+        const id = readJSON<string>('exam:lastSavedId') || editData?.id; 
+        if (id) { 
+          const h = snapshotHash({ title: aiMeta?.subject || 'Examen', subject: aiMeta?.subject, difficulty: aiMeta?.difficulty, questions: next }); 
+          const base = localStorage.getItem(`exam:snapshotHash:${id}`) || ''; 
+          localStorage.setItem(`exam:dirty:${id}`, h !== base ? '1' : '0'); 
+        } 
+      } catch {} 
+      return next; 
+    }); 
   };
 
   const onRegenerateAll = async () => {
@@ -297,6 +354,13 @@ export default function ExamsCreatePage() {
         }
         saveLocally();
         pushToast('Examen guardado exitosamente.', 'success');
+        try {
+          const id = String(summary.id);
+          localStorage.setItem('exam:lastSavedId', id);
+          const hash = snapshotHash({ title: aiMeta?.subject || 'Examen', subject: aiMeta?.subject, difficulty: aiMeta?.difficulty, questions });
+          localStorage.setItem(`exam:snapshotHash:${id}`, hash);
+          localStorage.setItem(`exam:dirty:${id}`, '0');
+        } catch {}
         navigate(courseId ? `/courses/${courseId}/periods/${classId}` : `/courses/${classId}`);
       } catch (error) {
         console.error('Error al guardar:', error);

--- a/client/src/services/exams.service.ts
+++ b/client/src/services/exams.service.ts
@@ -523,4 +523,78 @@ export async function deleteExamByCandidates(classId: string, candidates: Array<
   }
 }
 
+export function normalizeExamFromBE(be: any): {
+  id: string; title: string; subject?: string; difficulty?: string; createdAt?: string;
+  questions: GeneratedQuestion[];
+} {
+  const exam = be?.data?.exam ?? be?.exam ?? be;
+  const qs   = be?.data?.questions ?? be?.questions ?? [];
+  const mapKind = (k: string) =>
+    (k === 'MULTIPLE_CHOICE' ? 'multiple_choice'
+      : k === 'TRUE_FALSE' ? 'true_false'
+      : k === 'OPEN_ANALYSIS' ? 'open_analysis'
+      : 'open_exercise') as GeneratedQuestion['type'];
+
+  const questions: GeneratedQuestion[] = (qs || []).map((q: any, i: number) => {
+    const type = mapKind(q.kind);
+    const base = { id: String(q.id ?? i), type, text: String(q.text ?? ''), include: true } as GeneratedQuestion;
+    if (type === 'multiple_choice') {
+      const opts = Array.isArray(q.options) ? q.options.map(String) : [];
+      return { ...base, options: opts };
+    }
+    if (type === 'open_analysis') {
+      const opts = Array.isArray(q.options) ? q.options.map(String) : undefined;
+      return { ...base, options: opts };
+    }
+    return base;
+  });
+
+  return {
+    id: String(exam?.id ?? ''),
+    title: String(exam?.title ?? 'Examen'),
+    subject: String(exam?.subject ?? ''),
+    difficulty: String(exam?.difficulty ?? ''),
+    createdAt: String(exam?.createdAt ?? ''),
+    questions,
+  };
+}
+
+export async function getExamById(examId: string) {
+  const { data } = await api.get(`/api/exams/${examId}`);
+  return normalizeExamFromBE(data ?? {});
+}
+
+function stableStringify(obj: any): string {
+  const seen = new WeakSet();
+  return JSON.stringify(obj, function (_k, value) {
+    if (value && typeof value === 'object') {
+      if (seen.has(value)) return;
+      seen.add(value);
+      const keys = Object.keys(value).sort();
+      const out: any = {};
+      for (const k of keys) out[k] = (value as any)[k];
+      return out;
+    }
+    return value;
+  });
+}
+
+export function snapshotHash(payload: { title?: string; subject?: string; difficulty?: string; questions: GeneratedQuestion[] }): string {
+  const minimal = {
+    title: payload.title ?? '',
+    subject: payload.subject ?? '',
+    difficulty: payload.difficulty ?? '',
+    questions: (payload.questions || []).map(q => ({
+      type: q.type,
+      text: q.text,
+      options: q.type === 'multiple_choice' || q.type === 'open_analysis' ? (q.options ?? []) : undefined,
+      include: q.include !== false,
+    })),
+  };
+  const s = stableStringify(minimal);
+  let h = 5381;
+  for (let i = 0; i < s.length; i++) h = ((h << 5) + h) ^ s.charCodeAt(i);
+  return (h >>> 0).toString(16);
+}
+
 export default { generateQuestions, createExam, createExamApproved };


### PR DESCRIPTION
## Criterios de aceptación

### #154 — Lectura fiel para precargar editor y listar
- [x] **GET `/api/exams/:examId`** devuelve el examen completo y actualizado con:  
  `id, title, classId, status, createdAt, updatedAt, questions[]` y por pregunta:  
  `id, kind, order, text, options[]` + **correcta** (`correctOptionIndex` | `correctBoolean` | `expectedAnswer`) y campo derivado `correctAnswer` cuando aplica.
- [x] **GET `/api/classes/:classId/exams`** refleja cambios recientes (ordenado por `updatedAt desc`) tras una edición.
- [x] **Propiedad verificada**: docentes sin ownership **no pueden leer** (401/403). Recurso inexistente → 404.

### #155 — Guardar ediciones de preguntas (texto, opciones, correcta y orden)
- [x] **PUT `/api/exams/questions/:questionId`** guarda **enunciado**, **opciones** (reemplazo completo para MCQ), **respuesta correcta** y **order** (reordenamiento dentro del examen) **en una sola transacción**.
- [x] Lectura inmediata con **GET `/api/exams/:examId`** devuelve **exactamente lo editado**.
- [x] Validaciones y errores claros:
  - [x] 400 si datos inválidos (p. ej., `correctOptionIndex` fuera de rango, `order < 0`).
  - [x] 404/403 si la pregunta no existe o no pertenece al docente.
  - [x] 401 si no hay credenciales (JWT).

### #156 — Exportar/descargar siempre con datos frescos
- [x] Al exportar, el documento usa lo **último guardado** (misma fuente de verdad que el editor).
- [x] Si se intenta exportar con cambios locales **sin guardar**, el **frontend** muestra aviso (“guarda antes de exportar”).  
  Además, si el cliente usa un `If-Match` **desactualizado**, el **backend** responde **`412 Precondition Failed`** como señal clara.
- [x] No hay discrepancias entre lo que se ve en pantalla y lo que sale en el PDF (ambos leen el mismo `GET /api/exams/:id`).

---

## Archivos modificados

- `backend/src/modules/exams/infrastructure/persistence/exam.prisma.repository.ts`  
- `backend/src/modules/exams/domain/ports/exam-question.repository.port.ts`  
- `backend/src/modules/exams/infrastructure/http/dtos/update-exam-question.dto.ts`  
- `backend/src/modules/exams/infrastructure/http/exams.controller.ts`  
- `backend/src/modules/exams/infrastructure/persistence/exam-question.prisma.repository.ts`  
- *(opcional, validación extra)* `backend/src/modules/exams/application/commands/update-exam-question.handler.ts`

> **Notas**  
> - No se crearon archivos nuevos.  
> - No se tocaron otros módulos ni archivos globales.  
> - Cambios encapsulados al módulo **exams**.

---

## Cambios realizados

### `backend/src/modules/exams/infrastructure/persistence/exam.prisma.repository.ts`
- **Lista por curso** ahora ordenada por ediciones recientes:
  - **Antes:** `orderBy: [{ createdAt: 'desc' }]`
  - **Ahora:** `orderBy: [{ updatedAt: 'desc' }]`

### `backend/src/modules/exams/domain/ports/exam-question.repository.port.ts`
- Se amplía el **patch** de actualización de pregunta:
  - **Añadido:** `order?: number | null;`  
  Permite solicitar reordenamiento dentro del examen.

### `backend/src/modules/exams/infrastructure/http/dtos/update-exam-question.dto.ts`
- DTO acepta los campos del criterio:
  - `text?: string`
  - `options?: string[]`
  - `correctOptionIndex?: number`
  - `correctBoolean?: boolean`
  - `expectedAnswer?: string`
  - **Nuevo:** `order?: number` (validado con `@IsInt() @Min(0)`)

### `backend/src/modules/exams/infrastructure/http/exams.controller.ts`
- **#154:** mantiene `@UseGuards(JwtAuthGuard)`, `@UsePipes(ValidationPipe)` y el filtro del módulo; `GET /api/exams/:id` devuelve meta + preguntas con “correcta” (y `updatedAt`).  
- **#155:** en **`PUT /api/exams/questions/:questionId`** se pasa `order` del DTO al Command/Repository junto con texto, opciones y correcta.  
- **#156:** se añaden **ETag** y **Last-Modified** a `GET /api/exams/:id` (cálculo a partir de `updatedAt` + `id`), habilitando:
  - `If-None-Match` y `If-Modified-Since` para lecturas condicionales (evita descargar viejo).
  - `If-Match` en preflight de exportación: si el ETag no coincide con el actual, responde **`412 Precondition Failed`** para forzar el mensaje “guarda antes de exportar”.

### `backend/src/modules/exams/infrastructure/persistence/exam-question.prisma.repository.ts`
- **Transacción** de actualización ampliada (#155):
  - Reemplazo **completo** de opciones MCQ (deleteMany/createMany con `idx`).
  - Validación de `correctOptionIndex` vs cantidad de opciones.
  - Actualización de `correctBoolean`/`expectedAnswer` según tipo de pregunta.
  - **Reordenamiento** cuando llega `order` (ajuste de rangos y set del nuevo `order`).  
  - **Se “toca” `exam.updatedAt`** tras cambios de pregunta para que la **lista por curso** refleje el cambio inmediatamente.

---

## Postman

**URL base**: `{{base_url}}` (ej. `http://localhost:3000`)  
**Auth**: `Authorization: Bearer {{jwt}}`

### Requests

1. **Leer examen completo (precargar editor)**  
   `GET {{base_url}}/api/exams/{{examId}}`  
   Esperado: `200 OK` con `exam` + `questions[]` incluyendo correcta (`correctAnswer` cuando aplica).  
   Responde headers: `ETag: "W/\"<hash>\""`, `Last-Modified: <RFC1123>`

2. **Listar por curso (refresca tras edición)**  
   `GET {{base_url}}/api/classes/{{classId}}/exams`  
   Esperado: `200 OK` ordenado por `updatedAt desc`.

3. **Editar pregunta (MCQ ejemplo: texto, opciones, correcta, orden)**  
   `PUT {{base_url}}/api/exams/questions/{{questionId}}`  
   Body:  
   ```json
   {
     "text": "¿Capital de Francia?",
     "options": ["Madrid", "París", "Roma"],
     "correctOptionIndex": 1,
     "order": 0
   }
   ```
   Esperado: `200 OK`. Un `GET /api/exams/{{examId}}` inmediato refleja el cambio y actualiza `ETag`/`Last-Modified`.

4. **Preflight de exportación con If-Match (datos frescos)**  
   `GET {{base_url}}/api/exams/{{examId}}` con header `If-Match: "<etag-almacenado>"`  
   - Si coincide → `200 OK` (o `304 Not Modified` si usas `If-None-Match`) y se puede exportar.  
   - Si **no** coincide → **`412 Precondition Failed`** (backend emite señal clara: “actualiza/guarda antes de exportar”).

5. **True/False (correcta booleana)**  
   `PUT {{base_url}}/api/exams/questions/{{questionId}}`  
   ```json
   { "text": "El agua hierve a 100°C a nivel del mar", "correctBoolean": true }
   ```

6. **Abierta (respuesta esperada)**  
   `PUT {{base_url}}/api/exams/questions/{{questionId}}`  
   ```json
   { "text": "Demuestra el Teorema de Pitágoras", "expectedAnswer": "Borrador de demostración..." }
   ```

7. **Errores esperados**
   - `401 Unauthorized` sin `Bearer`.
   - `404 Not Found / 403` si no existe o no es del docente.
   - `400 Bad Request` si `correctOptionIndex` está fuera de rango o `order < 0`.
   - **`412 Precondition Failed`** si `If-Match` no coincide (señal para exportación fresca).

---

## Casos de prueba en Postman

| Caso | Request | Body | Headers | Respuesta esperada |
|------|---------|------|---------|--------------------|
| **200 OK – Lectura fiel** | GET `/api/exams/{{examId}}` | — | — | `exam` con `questions[]` y correcta; `ETag` y `Last-Modified` presentes. |
| **200 OK – Lista actualizada** | GET `/api/classes/{{classId}}/exams` | — | — | Lista ordenada por `updatedAt desc` (tras editar sube). |
| **200 OK – Editar MCQ** | PUT `/api/exams/questions/{{questionId}}` | `{ "text":"¿Capital de Francia?","options":["Madrid","París","Roma"],"correctOptionIndex":1,"order":0 }` | — | Pregunta actualizada; lectura inmediata refleja cambios y nuevo ETag. |
| **412 Precondition Failed – Export con ETag viejo** | GET `/api/exams/{{examId}}` | — | `If-Match: "<etag-viejo>"` | 412 con mensaje “Hay cambios recientes, actualiza antes de exportar”. |
| **401 Unauthorized** | Cualquier endpoint sin token | — | — | 401. |

---

## Nota final
- **Backend listo**: Postman verifica #154/#155/#156.  
- **Frontend pendiente**: ajuste de wiring para usar `updatedAt/ETag` y bloquear exportación si hay `dirty` local o si el `If-Match` retorna `412`.
